### PR TITLE
add unit tests for newestContainer and postPreviewCard

### DIFF
--- a/src/lib/components/__test__/PostPreviewCard.spec.tsx
+++ b/src/lib/components/__test__/PostPreviewCard.spec.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import PostPreviewCard from '../PostPreview/PostPreviewCard';
+import MOCK_NEWEST from '../../../modules/main/components/constants/newestPosts-mock';
+import { DIRECTION_PROPERTIES } from '../PostPreview/direction-properties';
+import { postTypeProperties } from '../PostPreview/post-type-properties';
+
+const { direction, postType } = MOCK_NEWEST[0];
+
+beforeEach(() => render(<PostPreviewCard data={MOCK_NEWEST[0]} />));
+
+describe('PostPreviewCard', () => {
+  it('renders cyrillic direction', () => {
+    const renderedDirection = screen.getByText(
+      DIRECTION_PROPERTIES[direction].cyrillic,
+    );
+
+    expect(renderedDirection).toBeInTheDocument();
+  });
+
+  it('renders cyrillic postType', () => {
+    const renderedPostType = screen.getByText(
+      postTypeProperties[postType].cyrillic,
+    );
+
+    expect(renderedPostType).toBeInTheDocument();
+  });
+});

--- a/src/modules/main/components/__test__/NewestContainer.spec.tsx
+++ b/src/modules/main/components/__test__/NewestContainer.spec.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import { Provider } from 'react-redux';
+import { render, screen } from '@testing-library/react';
+import NewestContainer from '../NewestContainer';
+import { store } from '../../../../store/store';
+import MOCK_NEWEST from '../constants/newestPosts-mock';
+import { fetchNewestPosts, loadNewest } from '../../store/mainSlice';
+
+import { LOAD_POSTS_LIMIT } from '../constants/newestPostsPagination-config';
+
+describe('newest', () => {
+  it('initial render NewestContainer posts equal to LIMIT number', () => {
+    render(
+      <Provider store={store}>
+        <NewestContainer />
+      </Provider>,
+    );
+
+    const renderedPostCount = screen.getByText('Найновіше').nextElementSibling
+      ?.childElementCount;
+
+    expect(renderedPostCount).toEqual(LOAD_POSTS_LIMIT);
+  });
+
+  it('state posts number equal to posts mock number', () => {
+    const newState = loadNewest({
+      newestPosts: MOCK_NEWEST,
+      meta: { currentIndex: 0 },
+    });
+
+    expect(newState.payload.newestPosts.length).toEqual(MOCK_NEWEST.length);
+  });
+
+  it('appended posts equal on LIMIT number', () => {
+    const prevState = store.getState().main.newest.newestPosts.length;
+
+    store.dispatch(fetchNewestPosts());
+
+    const newState = store.getState().main.newest.newestPosts.length;
+
+    expect(newState).toEqual(prevState + LOAD_POSTS_LIMIT);
+  });
+
+  it('showMore is equal to false whe currentIndex >= total posts number', () => {
+    store.dispatch(
+      loadNewest({
+        newestPosts: MOCK_NEWEST,
+        meta: { currentIndex: MOCK_NEWEST.length - LOAD_POSTS_LIMIT },
+      }),
+    );
+
+    store.dispatch(fetchNewestPosts());
+
+    const { showMore } = store.getState().main.newest.meta;
+    expect(showMore).toBeFalsy();
+  });
+});


### PR DESCRIPTION
Unit testing

## GitHub Board

**Issue link**

[#20  ]( https://github.com/ita-social-projects/dokazovi-fe/issues/20 )

## Summary of change

- [x]  PostPreviewCard unit testing 

- Render cyrillic postType
- Render cyrillic direction

- [x]  NewestContainer

- Load posts to state
- Append posts with thunk
- Change showMore button status