### PR TITLE
Issue 68 load be experts

### DIFF
--- a/src/lib/components/ExpertDataCard.tsx
+++ b/src/lib/components/ExpertDataCard.tsx
@@ -14,7 +14,7 @@ const ExpertDataCard: React.FC<IExpertDataCardProps> = (props) => {
   const { expert } = props;
 
   const fullName = `${expert.firstName} ${expert.lastName}`;
-  const directionName = expert.mainDirection ? expert.mainDirection.name : '';
+  const directionName = expert.mainDirection?.name || '';
 
   const classes = useStyles();
 

--- a/src/lib/components/ExpertDataCard.tsx
+++ b/src/lib/components/ExpertDataCard.tsx
@@ -4,7 +4,6 @@ import Card from '@material-ui/core/Card';
 import CardContent from '@material-ui/core/CardContent';
 import Typography from '@material-ui/core/Typography';
 import { IExpert } from '../types';
-import { DIRECTION_PROPERTIES } from '../constants/direction-properties';
 import { useStyles } from '../styles/ExpertDataCard.styles';
 
 export interface IExpertDataCardProps {
@@ -15,10 +14,7 @@ const ExpertDataCard: React.FC<IExpertDataCardProps> = (props) => {
   const { expert } = props;
 
   const fullName = `${expert.firstName} ${expert.lastName}`;
-
-  const directionName = expert.direction
-    ? DIRECTION_PROPERTIES[expert.direction].name
-    : '';
+  const directionName = expert.mainDirection ? expert.mainDirection.name : '';
 
   const classes = useStyles();
 
@@ -38,13 +34,14 @@ const ExpertDataCard: React.FC<IExpertDataCardProps> = (props) => {
             Спеціалізація: {directionName}
           </Typography>
           <Typography className={classes.pos} variant="body1" component="h2">
-            {expert.workPlace}
+            {expert.mainInstitution?.city?.name}, {expert.mainInstitution?.name}
           </Typography>
+          <Typography variant="body1">{expert.qualification}</Typography>
           <Typography variant="body2" color="textSecondary">
             Останній доданий матеріал:
           </Typography>
           <Typography variant="h6" component="p">
-            {expert.lastPost}
+            {expert.lastAddedPost?.title}
           </Typography>
         </Box>
       </CardContent>

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -46,14 +46,7 @@ export interface IExpert {
   firstName: string;
   id?: number;
   lastName: string;
-  mainInstitution?: {
-    city: {
-      id: number;
-      name: string;
-    };
-    id: number;
-    name: string;
-  };
+  mainInstitution?: IInstitution;
   mainDirection?: IDirection;
   lastAddedPost?: {
     id: number;
@@ -64,11 +57,24 @@ export interface IExpert {
   email?: string;
   directions?: DirectionEnum;
   bio?: string;
+  status?: ExpertStatus;
+  direction?: DirectionEnum;
+  workPlace?: string;
+  lastPost?: string;
 }
 
 export interface IDirection {
   id?: number;
-  color: string;
+  color?: string;
   name: string;
   route?: string;
+}
+
+export interface IInstitution {
+  city: {
+    id?: number;
+    name: string;
+  };
+  id?: number;
+  name: string;
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -54,12 +54,16 @@ export interface IExpert {
     id: number;
     name: string;
   };
-  status?: ExpertStatus;
-  direction?: DirectionEnum;
-  email?: string;
+  mainDirection?: IDirection;
+  lastAddedPost?: {
+    id: number;
+    title: string;
+  };
+  qualification?: string;
   phone?: string;
-  workPlace?: string;
-  lastPost?: string;
+  email?: string;
+  directions?: DirectionEnum;
+  bio?: string;
 }
 
 export interface IDirection {

--- a/src/modules/direction/components/DirectionView.tsx
+++ b/src/modules/direction/components/DirectionView.tsx
@@ -11,14 +11,15 @@ import { fetchExperts, setupDirection } from '../store/directionSlice';
 import { ExpertsView } from '../../../lib/components/ExpertsView';
 import { IDirection } from '../../../lib/types';
 
-export interface IDirectionViewProps { }
+export interface IDirectionViewProps {}
 
 const DirectionView: React.FC<IDirectionViewProps> = () => {
   const { pathname } = useLocation();
   const directions = Object.values(DIRECTION_PROPERTIES);
   const currentDirection = directions.find(
-    (value) => value.route === pathname.split('/')[2],
+    (direction) => direction.route === pathname.split('/')[2],
   ) as IDirection; // TODO: validate route!
+  console.log(currentDirection);
 
   const dispatch = useDispatch();
 
@@ -27,45 +28,54 @@ const DirectionView: React.FC<IDirectionViewProps> = () => {
   }, []);
 
   useEffect(() => {
-    dispatch(fetchExperts(currentDirection.name));
+    dispatch(
+      fetchExperts(currentDirection.name, currentDirection.id as number),
+    );
   }, []);
 
-  const expertsCards = useSelector((state: RootStateType) => state.directions[currentDirection.name]?.experts
-);
+  const expertsCards = useSelector(
+    (state: RootStateType) => state.directions[currentDirection.name]?.experts,
+  );
 
   const classes = useStyles();
 
   return (
     <>
-      <Container>
-        <Grid container spacing={2} direction="row">
-          <Grid item xs={12} className={classes.header}>
-            <Box
-              color="disabled"
-              className={classes.icon}
-              style={{ backgroundColor: currentDirection?.color }}
-            />
-            <Typography variant="h2">{currentDirection?.name}</Typography>
+      {currentDirection ? (
+        <Container>
+          <Grid container spacing={2} direction="row">
+            <Grid item xs={12} className={classes.header}>
+              <Box
+                color="disabled"
+                className={classes.icon}
+                style={{ backgroundColor: currentDirection?.color }}
+              />
+              <Typography variant="h2">{currentDirection?.name}</Typography>
+            </Grid>
+            <BorderBottom />
+            <Grid item xs={12}>
+              {expertsCards && <ExpertsView cards={expertsCards} />}
+              <Box className={classes.moreExperts}>
+                <Typography variant="h5" align="right" display="inline">
+                  Більше експертів
+                </Typography>
+                <ArrowForwardIosIcon />
+              </Box>
+            </Grid>
+            <BorderBottom />
+            <Grid item xs={12}>
+              {/* <MaterialsView /> */}
+            </Grid>
+            <Grid item xs={12}>
+              {/* <CoursesView /> */}
+            </Grid>
           </Grid>
-          <BorderBottom />
-          <Grid item xs={12}>
-            {expertsCards && <ExpertsView cards={expertsCards} />}
-            <Box className={classes.moreExperts}>
-              <Typography variant="h5" align="right" display="inline">
-                Більше експертів
-              </Typography>
-              <ArrowForwardIosIcon />
-            </Box>
-          </Grid>
-          <BorderBottom />
-          <Grid item xs={12}>
-            {/* <MaterialsView /> */}
-          </Grid>
-          <Grid item xs={12}>
-            {/* <CoursesView /> */}
-          </Grid>
-        </Grid>
-      </Container>
+        </Container>
+      ) : (
+        <>
+          <Typography variant="h3">Direction not found</Typography>
+        </>
+      )}
     </>
   );
 };

--- a/src/modules/direction/components/DirectionView.tsx
+++ b/src/modules/direction/components/DirectionView.tsx
@@ -19,7 +19,6 @@ const DirectionView: React.FC<IDirectionViewProps> = () => {
   const currentDirection = directions.find(
     (direction) => direction.route === pathname.split('/')[2],
   ) as IDirection; // TODO: validate route!
-  console.log(currentDirection);
 
   const dispatch = useDispatch();
 

--- a/src/modules/direction/components/styles/DirectionView.styles.ts
+++ b/src/modules/direction/components/styles/DirectionView.styles.ts
@@ -16,6 +16,7 @@ export const useStyles = makeStyles(
       alignItems: 'center',
       justifyContent: 'flex-end',
       cursor: 'pointer',
+      marginTop: 20,
     },
   },
   {

--- a/src/modules/direction/store/directionSlice.ts
+++ b/src/modules/direction/store/directionSlice.ts
@@ -1,11 +1,9 @@
 /* eslint-disable no-param-reassign */
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
-import MOCK_EXPERTS from '../../main/mockDataExperts';
-import { IDirection, IExpert } from '../../../lib/types';
+import * as _ from 'lodash';
+import { IExpert } from '../../../lib/types';
 import type { AppThunkType } from '../../../store/store';
 import { getExperts } from '../../../lib/utilities/API/api';
-import { DIRECTION_PROPERTIES } from '../../../lib/constants/direction-properties';
-import { postTypeProperties } from '../../../lib/constants/post-type-properties';
 
 export interface IDirectionsState extends Record<string, IDirectionState> {
   [key: string]: IDirectionState;
@@ -51,24 +49,15 @@ export const fetchExperts = (
   directionId: number,
 ): AppThunkType => async (dispatch) => {
   try {
-    // const experts = await Promise.resolve(MOCK_EXPERTS);
-    const bExperts = await getExperts({
+    const loadedExperts = await getExperts({
       params: {
         directions: [directionId],
+        size: 11,
       },
     });
-    console.log(bExperts);
-    const experts = bExperts.data.content.map((expert) => {
-      return {
-        id: expert.id,
-        avatar: expert.avatar,
-        firstName: expert.firstName,
-        lastName: expert.lastName,
-        mainDirection: expert.mainDirection as IDirection,
-        mainInstitution: expert.mainInstitution,
-        qualification: expert.qualification,
-        lastAddedPost: expert.lastAddedPost,
-      };
+
+    const experts = loadedExperts.data.content.map((expert) => {
+      return { ...(expert as IExpert) };
     });
 
     dispatch(

--- a/src/modules/direction/store/directionSlice.ts
+++ b/src/modules/direction/store/directionSlice.ts
@@ -1,6 +1,5 @@
 /* eslint-disable no-param-reassign */
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
-import * as _ from 'lodash';
 import { IExpert } from '../../../lib/types';
 import type { AppThunkType } from '../../../store/store';
 import { getExperts } from '../../../lib/utilities/API/api';
@@ -56,9 +55,9 @@ export const fetchExperts = (
       },
     });
 
-    const experts = loadedExperts.data.content.map((expert) => {
-      return { ...(expert as IExpert) };
-    });
+    const experts = loadedExperts.data.content.map((expert) => ({
+      ...(expert as IExpert),
+    }));
 
     dispatch(
       loadExperts({

--- a/src/modules/direction/store/directionSlice.ts
+++ b/src/modules/direction/store/directionSlice.ts
@@ -1,11 +1,14 @@
 /* eslint-disable no-param-reassign */
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import MOCK_EXPERTS from '../../main/mockDataExperts';
-import { IExpert } from '../../../lib/types';
+import { IDirection, IExpert } from '../../../lib/types';
 import type { AppThunkType } from '../../../store/store';
+import { getExperts } from '../../../lib/utilities/API/api';
+import { DIRECTION_PROPERTIES } from '../../../lib/constants/direction-properties';
+import { postTypeProperties } from '../../../lib/constants/post-type-properties';
 
 export interface IDirectionsState extends Record<string, IDirectionState> {
-  [key: string]: IDirectionState
+  [key: string]: IDirectionState;
 }
 
 export interface IDirectionState {
@@ -26,9 +29,9 @@ export const directionsSlice = createSlice({
     loadExperts: (
       state,
       action: PayloadAction<{
-        experts: IExpert[],
-        directionName: string,
-      }>
+        experts: IExpert[];
+        directionName: string;
+      }>,
     ) => {
       const { directionName } = action.payload;
       const direction = state[directionName] as IDirectionState;
@@ -43,13 +46,37 @@ export const { loadExperts, setupDirection } = directionsSlice.actions;
 
 export const directionsReducer = directionsSlice.reducer;
 
-export const fetchExperts = (directionName: string): AppThunkType => async (dispatch) => {
+export const fetchExperts = (
+  directionName: string,
+  directionId: number,
+): AppThunkType => async (dispatch) => {
   try {
-    const experts = await Promise.resolve(MOCK_EXPERTS);
-    dispatch(loadExperts({
-      directionName,
-      experts,
-    }));
+    // const experts = await Promise.resolve(MOCK_EXPERTS);
+    const bExperts = await getExperts({
+      params: {
+        directions: [directionId],
+      },
+    });
+    console.log(bExperts);
+    const experts = bExperts.data.content.map((expert) => {
+      return {
+        id: expert.id,
+        avatar: expert.avatar,
+        firstName: expert.firstName,
+        lastName: expert.lastName,
+        mainDirection: expert.mainDirection as IDirection,
+        mainInstitution: expert.mainInstitution,
+        qualification: expert.qualification,
+        lastAddedPost: expert.lastAddedPost,
+      };
+    });
+
+    dispatch(
+      loadExperts({
+        directionName,
+        experts,
+      }),
+    );
   } catch (e) {
     console.log(e);
   }


### PR DESCRIPTION
Issue 68 load BE experts for direction page

## GitHub Board

**Issue link**

[#68 Direction: Direction page + Experts](https://github.com/ita-social-projects/dokazovi-fe/issues/68 )

**Story link**

[#14 As a user(any role)I want to view the pictures of experts, having appropriate specialization in "Experts" section](https://github.com/ita-social-projects/dokazovi-be/issues/14 )

## Summary of issue

- [x]  load the data from the BE

## Summary of change

- [x]   use axios to perform a GET request
- [x]  use redux store to perform a fetch action, store and get the data to the component
