### PR TITLE
feat:add redirect to expert profile page

### DIFF
--- a/src/lib/components/ExpertDataCard.tsx
+++ b/src/lib/components/ExpertDataCard.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useHistory } from 'react-router-dom';
 import { Box } from '@material-ui/core';
 import Card from '@material-ui/core/Card';
 import CardContent from '@material-ui/core/CardContent';
@@ -13,11 +14,15 @@ export interface IExpertDataCardProps {
 
 const ExpertDataCard: React.FC<IExpertDataCardProps> = (props) => {
   const { expert } = props;
-
+  const history = useHistory();
   const fullName = `${expert.firstName} ${expert.lastName}`;
   const mainInsitutionCity = expert.mainInstitution?.city?.name || '';
   const mainInsitutionName = expert.mainInstitution?.name || '';
   const direction = expert.mainDirection;
+
+  const handleClick = () => {
+    history.push(`/experts/${expert.id as number}`);
+  };
 
   const classes = useStyles();
 
@@ -32,7 +37,13 @@ const ExpertDataCard: React.FC<IExpertDataCardProps> = (props) => {
             justifyContent: 'space-around',
           }}
         >
-          <Typography variant="h5">{fullName}</Typography>
+          <Typography
+            className={classes.name}
+            onClick={handleClick}
+            variant="h5"
+          >
+            {fullName}
+          </Typography>
           {direction && (
             <Typography variant="body1">
               Спеціалізація: <PostDirectionLink direction={direction} />
@@ -42,7 +53,12 @@ const ExpertDataCard: React.FC<IExpertDataCardProps> = (props) => {
             <Typography variant="body1" component="h2">
               {mainInsitutionCity}
             </Typography>
-            <Typography className={classes.pos} variant="body1" component="h2">
+            <Typography
+              className={classes.pos}
+              onClick={handleClick}
+              variant="body1"
+              component="h2"
+            >
               {mainInsitutionName}
             </Typography>
           </div>

--- a/src/lib/styles/ExpertDataCard.styles.ts
+++ b/src/lib/styles/ExpertDataCard.styles.ts
@@ -8,6 +8,10 @@ export const useStyles = makeStyles(
     },
     pos: {
       marginBottom: 12,
+      cursor: 'pointer',
+    },
+    name: {
+      cursor: 'pointer',
     },
   },
   {

--- a/src/modules/experts/store/expertsSlice.ts
+++ b/src/modules/experts/store/expertsSlice.ts
@@ -144,7 +144,6 @@ export const expertsSlice = createSlice({
     builder.addCase(fetchExperts.fulfilled, (state, { payload }) => {
       state.experts.meta.loading = LoadingStatusEnum.succeeded;
       state.experts.meta.pageNumber = payload.number;
-      state.experts.meta.totalPages = payload.totalPages;
       state.experts.meta.totalPages = payload.totalPages - 1;
       state.experts.experts = payload.content;
     });

--- a/src/modules/experts/store/expertsSlice.ts
+++ b/src/modules/experts/store/expertsSlice.ts
@@ -56,7 +56,7 @@ const initialState: IExpertsState = {
   experts: {
     experts: [],
     meta: {
-      totalPages: 0,
+      totalPages: undefined,
       pageNumber: 1,
       loading: LoadingStatusEnum.idle,
       error: null,
@@ -145,7 +145,7 @@ export const expertsSlice = createSlice({
       state.experts.meta.loading = LoadingStatusEnum.succeeded;
       state.experts.meta.pageNumber = payload.number;
       state.experts.meta.totalPages = payload.totalPages;
-      state.experts.meta.totalPages -= 1;
+      state.experts.meta.totalPages = payload.totalPages - 1;
       state.experts.experts = payload.content;
     });
     builder.addCase(fetchExperts.rejected, (state, { error }) => {


### PR DESCRIPTION
Redirect to expert profile page

## GitHub Board

**Issue link**

[Experts List: Experts Pagination and Grid #115](https://github.com/ita-social-projects/dokazovi-fe/issues/115)

**Story link**

[As a user(any role) I want to view Experts list on "Experts" page #90](https://github.com/ita-social-projects/dokazovi-be/issues/90)

## Summary of issue

- [x] Redirect from ExpertDataCard to ExpertProfile page

## Summary of change

- [x] Redirect when clicking on fullName and on "place of work"
- [x] Minor fixes in expertsSlice initialState
