### PR TITLE
Custom buttons

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,8 @@
     "lodash": "^4.17.20",
     "qs": "^6.9.4",
     "quill": "^1.3.7",
+    "quill-image-resize-module-react": "^3.0.0",
+    "quill-image-uploader": "^1.2.2",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
     "react-hook-form": "^6.12.2",

--- a/src/lib/components/Editor/CustomModules/ImageFromURLHandler.ts
+++ b/src/lib/components/Editor/CustomModules/ImageFromURLHandler.ts
@@ -1,0 +1,24 @@
+import { Quill } from 'react-quill';
+import { postImage } from '../../../utilities/API/imgurApi';
+
+const insertFromUrl = (editor?: Quill) => {
+  const url: string | null = prompt(
+    'Введіть посилання на зображення https://www...',
+  );
+
+  if (editor && url) {
+    const range = editor.getSelection(true);
+
+    postImage(url)
+      .then((resp) => {
+        if (resp.data.data.link) {
+          editor.insertEmbed(range.index, 'image', resp.data.data.link);
+          range.index += 1;
+          editor.setSelection(range);
+        }
+      })
+      .catch((e) => String(e));
+  }
+};
+
+export default insertFromUrl;

--- a/src/lib/components/Editor/CustomModules/ImageHandlersContainer.tsx
+++ b/src/lib/components/Editor/CustomModules/ImageHandlersContainer.tsx
@@ -1,0 +1,52 @@
+import { IconButton } from '@material-ui/core';
+import React from 'react';
+import { Quill } from 'react-quill';
+import CropOriginalIcon from '@material-ui/icons/CropOriginal';
+import ImageFromURLHandler from './ImageFromURLHandler';
+
+export interface IImageHandlersContainerProps {
+  editor?: Quill;
+}
+
+const ImageHandlersContainer: React.FC<IImageHandlersContainerProps> = ({
+  editor,
+}) => {
+  const handleToggle = () => {
+    document.querySelector('.ImageHandlersContainer')?.classList.toggle('hide');
+  };
+
+  return (
+    <>
+      <span className="ql-formats">
+        <IconButton onClick={handleToggle} title="Додати зображення">
+          <CropOriginalIcon
+            fontSize="small"
+            style={{ width: '18px', height: '18px' }}
+          />
+        </IconButton>
+
+        <div className="ImageHandlersContainer hide">
+          <button
+            type="button"
+            className="ql-image MuiButtonBase-root MuiIconButton-root"
+            tabIndex={0}
+            title="З комп'ютера"
+          />
+          <IconButton
+            onClick={() => ImageFromURLHandler(editor)}
+            title="За посиланням"
+            disableRipple
+          >
+            <CropOriginalIcon
+              className="customSVGIcon"
+              fontSize="small"
+              style={{ width: '18px', height: '18px' }}
+            />
+          </IconButton>
+        </div>
+      </span>
+    </>
+  );
+};
+
+export default ImageHandlersContainer;

--- a/src/lib/components/Editor/Editors/ArticleEditor.tsx
+++ b/src/lib/components/Editor/Editors/ArticleEditor.tsx
@@ -5,15 +5,18 @@ import ArticleEditorToolbar from './ArticleEditorToolbar';
 
 const ArticleEditor: React.FC = () => {
   const [editor, setEditor] = useState<Quill>();
-  const myref = useRef<ReactQuill | null>(null);
+  const articleEditor = useRef<ReactQuill | null>(null);
 
   useEffect(() => {
-    setEditor(myref.current?.getEditor());
+    if (articleEditor.current) setEditor(articleEditor.current.getEditor());
   }, []);
 
   return (
     <>
-      <GeneralEditor toolbar={<ArticleEditorToolbar />} ref={myref} />
+      <GeneralEditor
+        toolbar={<ArticleEditorToolbar editor={editor} />}
+        ref={articleEditor}
+      />
     </>
   );
 };

--- a/src/lib/components/Editor/Editors/ArticleEditorToolbar.tsx
+++ b/src/lib/components/Editor/Editors/ArticleEditorToolbar.tsx
@@ -1,8 +1,15 @@
 import React from 'react';
 import { Quill } from 'react-quill';
+import ImageHandlersContainer from '../CustomModules/ImageHandlersContainer';
 import '../generalEditor.styles.css';
 
-const ArticleEditorToolbar: React.FC = () => {
+interface IArticleEditorToolbarProps {
+  editor?: Quill;
+}
+
+const ArticleEditorToolbar: React.FC<IArticleEditorToolbarProps> = ({
+  editor,
+}) => {
   return (
     <div id="toolbar">
       <span className="ql-formats">
@@ -59,9 +66,7 @@ const ArticleEditorToolbar: React.FC = () => {
       <span className="ql-formats">
         <select title="Align" className="ql-align" />
       </span>
-      <span className="ql-formats">
-        <button title="З комп'ютера" type="button" className="ql-image" />
-      </span>
+      <ImageHandlersContainer editor={editor} />
     </div>
   );
 };

--- a/src/lib/components/Editor/Editors/NoteEditor.tsx
+++ b/src/lib/components/Editor/Editors/NoteEditor.tsx
@@ -5,15 +5,18 @@ import NoteEditorToolbar from './NoteEditorToolbar';
 
 const NoteEditor: React.FC = () => {
   const [editor, setEditor] = useState<Quill>();
-  const myref = useRef<ReactQuill | null>(null);
+  const noteEditor = useRef<ReactQuill | null>(null);
 
   useEffect(() => {
-    setEditor(myref.current?.getEditor());
+    if (noteEditor.current) setEditor(noteEditor.current.getEditor());
   }, []);
 
   return (
     <>
-      <GeneralEditor toolbar={<NoteEditorToolbar />} ref={myref} />
+      <GeneralEditor
+        toolbar={<NoteEditorToolbar editor={editor} />}
+        ref={noteEditor}
+      />
     </>
   );
 };

--- a/src/lib/components/Editor/Editors/NoteEditorToolbar.tsx
+++ b/src/lib/components/Editor/Editors/NoteEditorToolbar.tsx
@@ -1,12 +1,13 @@
 import React from 'react';
 import { Quill } from 'react-quill';
+import ImageHandlersContainer from '../CustomModules/ImageHandlersContainer';
 import '../generalEditor.styles.css';
 
 export interface INoteEditorToolbarProps {
   editor?: Quill;
 }
 
-const NoteEditorToolbar: React.FC<INoteEditorToolbarProps> = () => {
+const NoteEditorToolbar: React.FC<INoteEditorToolbarProps> = ({ editor }) => {
   return (
     <div id="toolbar">
       <span className="ql-formats">
@@ -14,10 +15,7 @@ const NoteEditorToolbar: React.FC<INoteEditorToolbarProps> = () => {
         <button title="Bold" type="button" className="ql-bold" />
         <button title="Italic" type="button" className="ql-italic" />
       </span>
-
-      <span className="ql-formats">
-        <button title="З комп'ютера" type="button" className="ql-image" />
-      </span>
+      <ImageHandlersContainer editor={editor} />
     </div>
   );
 };

--- a/src/lib/components/Editor/GeneralEditor.tsx
+++ b/src/lib/components/Editor/GeneralEditor.tsx
@@ -8,7 +8,7 @@ export interface IQuillEditorProps {
   toolbar: React.ReactNode;
 }
 
-const QuillEditorComp = React.forwardRef<ReactQuill | null, IQuillEditorProps>(
+const GeneralEditor = React.forwardRef<ReactQuill, IQuillEditorProps>(
   ({ toolbar }, ref) => {
     const [text, setText] = useState<string>('');
     return (
@@ -30,4 +30,4 @@ const QuillEditorComp = React.forwardRef<ReactQuill | null, IQuillEditorProps>(
   },
 );
 
-export default QuillEditorComp;
+export default GeneralEditor;

--- a/src/lib/components/Editor/generalEditor.styles.css
+++ b/src/lib/components/Editor/generalEditor.styles.css
@@ -57,3 +57,24 @@ h2,
 p {
   line-height: 2rem;
 }
+
+.show {
+  display: block;
+}
+
+.hide {
+  display: none !important;
+}
+
+.customSVGIcon {
+  fill: #2c2c2c;
+}
+
+.customSVGIcon:hover {
+  fill: #06c;
+}
+
+.ImageHandlersContainer {
+  display: flex;
+  flex-direction: row;
+}

--- a/src/lib/components/Editor/icons.ts
+++ b/src/lib/components/Editor/icons.ts
@@ -1,0 +1,4 @@
+const className = 'customSVGIcon';
+
+export const computerIcon = `<div style="width: 18px; height: 18px;"><svg class=${className} focusable="false" viewBox="0 0 24 24" aria-hidden="true"><path d="M20 18c1.1 0 1.99-.9 1.99-2L22 6c0-1.1-.9-2-2-2H4c-1.1 0-2 .9-2 2v10c0 1.1.9 2 2 2H0v2h24v-2h-4zM4 6h16v10H4V6z"></path></svg></div>`;
+export const imageSearch = `<div style="width: 18px; height: 18px;"><svg class=${className}" focusable="false" viewBox="0 0 24 24" aria-hidden="true"><path d="M18 13v7H4V6h5.02c.05-.71.22-1.38.48-2H4c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2v-5l-2-2zm-1.5 5h-11l2.75-3.53 1.96 2.36 2.75-3.54zm2.8-9.11c.44-.7.7-1.51.7-2.39C20 4.01 17.99 2 15.5 2S11 4.01 11 6.5s2.01 4.5 4.49 4.5c.88 0 1.7-.26 2.39-.7L21 13.42 22.42 12 19.3 8.89zM15.5 9C14.12 9 13 7.88 13 6.5S14.12 4 15.5 4 18 5.12 18 6.5 16.88 9 15.5 9z"></path></svg></div>`;

--- a/src/lib/components/Editor/utilities.ts
+++ b/src/lib/components/Editor/utilities.ts
@@ -1,8 +1,40 @@
+import { Quill } from 'react-quill';
 import { StringMap } from 'quill';
+import ImageUploader from 'quill-image-uploader';
+import ImageResize from 'quill-image-resize-module-react';
+import { computerIcon } from './icons';
+import { postImage } from '../../utilities/API/imgurApi';
+
+Quill.register('modules/imageUploader', ImageUploader);
+Quill.register('modules/imageResize', ImageResize);
+
+// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+const Icons: StringMap = Quill.import('ui/icons');
+
+Icons.image = computerIcon;
 
 export const modules: StringMap = {
   toolbar: {
     container: '#toolbar',
+  },
+  imageResize: {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    parchment: Quill.import('parchment'),
+  },
+
+  imageUploader: {
+    upload: (file) => {
+      return new Promise((resolve, reject) => {
+        postImage(file)
+          .then((resp) => {
+            resolve(resp.data.data.link);
+          })
+          .catch((error) => {
+            reject(error);
+            console.error('Error:', error);
+          });
+      });
+    },
   },
   history: {
     delay: 500,

--- a/src/lib/utilities/API/imgurApi.ts
+++ b/src/lib/utilities/API/imgurApi.ts
@@ -1,0 +1,24 @@
+import axios, { AxiosResponse } from 'axios';
+
+const BASE_URL = 'https://api.imgur.com/3';
+const CLIENT_ID = '4415dae57a57524';
+
+export type ImgurPostResponseType = {
+  data: { deletehash: string; link: string };
+};
+
+export const postImage = (
+  url: string,
+  config = {
+    headers: {
+      Authorization: `Client-ID ${CLIENT_ID}`,
+    },
+  },
+): Promise<AxiosResponse<ImgurPostResponseType>> => {
+  const formData = new FormData();
+  formData.append('image', url);
+  return axios.post(`${BASE_URL}/image`, formData, {
+    method: 'post',
+    ...config,
+  });
+};


### PR DESCRIPTION
**Issue link**

[Quill custom buttons research #169 ]( https://github.com/ita-social-projects/dokazovi-fe/issues/169)

## Summary of change

- [x]  Added custom `image upload from url` button
- [x] Added icons file - for quill standard icons override stoves this [problem](https://github.com/quilljs/quill/issues/1099)
- [x]  Added imgur API
- [x] Added Image upload module [npm](https://www.npmjs.com/package/quill-image-uploader)
- [x] Added image resize module [npm](https://www.npmjs.com/package/@looop/quill-image-resize-module-react)
- [x] Added container for custom buttons
- [x] Integrated modules and custom buttons to the editors
