### PR TITLE
Issue 176 filter form improved reusability

### DIFF
--- a/src/lib/components/FilterForm.tsx
+++ b/src/lib/components/FilterForm.tsx
@@ -6,7 +6,6 @@ import Accordion from '@material-ui/core/Accordion';
 import AccordionSummary from '@material-ui/core/AccordionSummary';
 import AccordionDetails from '@material-ui/core/AccordionDetails';
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
-import _ from 'lodash';
 import { Grid, Typography } from '@material-ui/core';
 import { FilterPropertiesType } from '../types';
 

--- a/src/lib/components/FilterForm.tsx
+++ b/src/lib/components/FilterForm.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect } from 'react';
+import React from 'react';
 import FormGroup from '@material-ui/core/FormGroup';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
 import Checkbox from '@material-ui/core/Checkbox';
@@ -7,10 +7,8 @@ import AccordionSummary from '@material-ui/core/AccordionSummary';
 import AccordionDetails from '@material-ui/core/AccordionDetails';
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
 import _ from 'lodash';
-import { useDispatch } from 'react-redux';
 import { Grid, Typography } from '@material-ui/core';
-
-import { FilterPropertiesType, FilterTypeEnum, IPostType } from '../types';
+import { FilterPropertiesType } from '../types';
 
 export interface ICheckboxes {
   [key: string]: boolean;
@@ -20,109 +18,31 @@ export interface IObjForAction {
   value: ICheckboxes;
 }
 
+export type FilterTiltleType = 'Регіони:' | 'Напрямки:';
+
 export interface IFilterFormProps {
-  setFilter: (obj: IObjForAction) => void;
   filterProperties: FilterPropertiesType[];
-  filterType: FilterTypeEnum;
+  filterTitle: FilterTiltleType;
+  checkedNamesString: () => string;
+  allChecked: boolean;
+  checked: ICheckboxes;
+  onCheckboxAllChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
+  onCheckboxChange: (
+    event: React.ChangeEvent<HTMLInputElement>,
+    typeName: string,
+  ) => void;
 }
 
 export const FilterForm: React.FC<IFilterFormProps> = (props) => {
-  const { setFilter, filterProperties, filterType } = props;
-  const dispatch = useDispatch();
-
-  const initLocalState = filterProperties.reduce(
-    (acc: ICheckboxes, next: FilterPropertiesType) => {
-      return { ...acc, [next.id.toString()]: true };
-    },
-    {},
-  );
-
-  const initNamesState = filterProperties.map((type) => type.name);
-
-  const [checked, setChecked] = React.useState<ICheckboxes>(initLocalState);
-  const [allChecked, setAllChecked] = React.useState<boolean>(true);
-  const [checkedNames, setCheckedNames] = React.useState<string[]>(
-    initNamesState,
-  );
-
-  const filterTitle =
-    filterType === FilterTypeEnum.REGIONS ? 'Регіони:' : 'Напрямки:';
-
-  useEffect(() => {
-    return () => {
-      dispatch(
-        setFilter({
-          value: {},
-        }),
-      );
-    };
-  }, []);
-
-  useEffect(() => {
-    if (Object.values(checked).every((elem) => elem)) {
-      setAllChecked(true);
-    }
-  }, [checked]);
-
-  const setFilterWithDebounce = useCallback(
-    _.debounce((checkedTypes: ICheckboxes) => {
-      dispatch(
-        setFilter({
-          value: checkedTypes,
-        }),
-      );
-    }, 500),
-    [],
-  );
-
-  const handleChange = (
-    event: React.ChangeEvent<HTMLInputElement>,
-    typeName: string,
-  ) => {
-    const checkedTypes = {
-      ...checked,
-      [event.target.id]: event.target.checked,
-    };
-
-    if (!event.target.checked && allChecked) {
-      setAllChecked(false);
-    }
-
-    const newCheckedNames = event.target.checked
-      ? [...checkedNames, typeName]
-      : checkedNames.filter((name) => name !== typeName);
-
-    setChecked(checkedTypes);
-    setCheckedNames(newCheckedNames);
-    setFilterWithDebounce(checkedTypes);
-  };
-
-  const handleChangeAll = (event: React.ChangeEvent<HTMLInputElement>) => {
-    const checkedTypes = event.target.checked
-      ? _.mapValues(checked, () => true)
-      : _.mapValues(checked, () => false);
-
-    const newCheckedNames = event.target.checked
-      ? filterProperties.map((type) => type.name)
-      : [];
-
-    setChecked(checkedTypes);
-    setAllChecked(event.target.checked);
-    setCheckedNames(newCheckedNames);
-    setFilterWithDebounce(checkedTypes);
-  };
-
-  const checkedNamesString = () => {
-    if (allChecked) {
-      return 'Всі';
-    }
-    if (checkedNames.length < 4) {
-      return checkedNames.join(', ');
-    }
-    return `${checkedNames.slice(0, 3).join(', ')} + ${
-      checkedNames.length - 3
-    }`;
-  };
+  const {
+    filterProperties,
+    filterTitle,
+    checkedNamesString,
+    allChecked,
+    checked,
+    onCheckboxAllChange,
+    onCheckboxChange,
+  } = props;
 
   return (
     <>
@@ -153,7 +73,7 @@ export const FilterForm: React.FC<IFilterFormProps> = (props) => {
                     <Checkbox
                       id="All"
                       checked={allChecked}
-                      onChange={handleChangeAll}
+                      onChange={onCheckboxAllChange}
                       name="All"
                     />
                   }
@@ -177,7 +97,7 @@ export const FilterForm: React.FC<IFilterFormProps> = (props) => {
                       <Checkbox
                         id={type.id.toString()}
                         checked={checked[type.id.toString()]}
-                        onChange={(event) => handleChange(event, type.name)}
+                        onChange={(event) => onCheckboxChange(event, type.name)}
                         name={type.name}
                       />
                     }

--- a/src/lib/components/FilterFormContainer.tsx
+++ b/src/lib/components/FilterFormContainer.tsx
@@ -1,0 +1,134 @@
+import React, { useCallback, useEffect } from 'react';
+import _ from 'lodash';
+import { useDispatch } from 'react-redux';
+import { FilterPropertiesType, FilterTypeEnum, IPostType } from '../types';
+import { FilterForm } from './FilterForm';
+
+export interface ICheckboxes {
+  [key: string]: boolean;
+}
+
+export interface IObjForAction {
+  value: ICheckboxes;
+}
+
+export interface IFilterFormContainerProps {
+  setFilter: (obj: IObjForAction) => void;
+  filterProperties: FilterPropertiesType[];
+  filterType: FilterTypeEnum;
+}
+
+export const FilterFormContainer: React.FC<IFilterFormContainerProps> = (
+  props,
+) => {
+  const { setFilter, filterProperties, filterType } = props;
+  const dispatch = useDispatch();
+
+  const initLocalState = filterProperties.reduce(
+    (acc: ICheckboxes, next: FilterPropertiesType) => {
+      return { ...acc, [next.id.toString()]: true };
+    },
+    {},
+  );
+
+  const initNamesState = filterProperties.map((type) => type.name);
+
+  const [checked, setChecked] = React.useState<ICheckboxes>(initLocalState);
+  const [allChecked, setAllChecked] = React.useState<boolean>(true);
+  const [checkedNames, setCheckedNames] = React.useState<string[]>(
+    initNamesState,
+  );
+
+  const filterTitle =
+    filterType === FilterTypeEnum.REGIONS ? 'Регіони:' : 'Напрямки:';
+
+  useEffect(() => {
+    return () => {
+      dispatch(
+        setFilter({
+          value: {},
+        }),
+      );
+    };
+  }, []);
+
+  useEffect(() => {
+    if (Object.values(checked).every((elem) => elem)) {
+      setAllChecked(true);
+    }
+  }, [checked]);
+
+  const setFilterWithDebounce = useCallback(
+    _.debounce((checkedTypes: ICheckboxes) => {
+      dispatch(
+        setFilter({
+          value: checkedTypes,
+        }),
+      );
+    }, 500),
+    [],
+  );
+
+  const handleChange = (
+    event: React.ChangeEvent<HTMLInputElement>,
+    typeName: string,
+  ) => {
+    const checkedTypes = {
+      ...checked,
+      [event.target.id]: event.target.checked,
+    };
+
+    if (!event.target.checked && allChecked) {
+      setAllChecked(false);
+    }
+
+    const newCheckedNames = event.target.checked
+      ? [...checkedNames, typeName]
+      : checkedNames.filter((name) => name !== typeName);
+
+    setChecked(checkedTypes);
+    setCheckedNames(newCheckedNames);
+    setFilterWithDebounce(checkedTypes);
+  };
+
+  const handleChangeAll = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const checkedTypes = event.target.checked
+      ? _.mapValues(checked, () => true)
+      : _.mapValues(checked, () => false);
+
+    const newCheckedNames = event.target.checked
+      ? filterProperties.map((type) => type.name)
+      : [];
+
+    setChecked(checkedTypes);
+    setAllChecked(event.target.checked);
+    setCheckedNames(newCheckedNames);
+    setFilterWithDebounce(checkedTypes);
+  };
+
+  const checkedNamesString = () => {
+    if (allChecked) {
+      return 'Всі';
+    }
+    if (checkedNames.length < 4) {
+      return checkedNames.join(', ');
+    }
+    return `${checkedNames.slice(0, 3).join(', ')} + ${
+      checkedNames.length - 3
+    }`;
+  };
+
+  return (
+    <>
+      <FilterForm
+        filterProperties={filterProperties}
+        filterTitle={filterTitle}
+        checkedNamesString={checkedNamesString}
+        allChecked={allChecked}
+        checked={checked}
+        onCheckboxAllChange={handleChangeAll}
+        onCheckboxChange={handleChange}
+      />
+    </>
+  );
+};

--- a/src/lib/components/FilterFormContainer.tsx
+++ b/src/lib/components/FilterFormContainer.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useEffect } from 'react';
 import _ from 'lodash';
 import { useDispatch } from 'react-redux';
-import { FilterPropertiesType, FilterTypeEnum, IPostType } from '../types';
+import { FilterPropertiesType, FilterTypeEnum } from '../types';
 import { FilterForm } from './FilterForm';
 
 export interface ICheckboxes {

--- a/src/modules/experts/components/ExpertsView.tsx
+++ b/src/modules/experts/components/ExpertsView.tsx
@@ -12,8 +12,8 @@ import { RootStateType } from '../../../store/rootReducer';
 import ExpertsList from '../../../lib/components/ExpertsList';
 import LoadingInfo from '../../../lib/components/LoadingInfo';
 import { useStyles } from '../styles/ExpertsView.styles';
-import { FilterForm } from '../../../lib/components/FilterForm';
 import { FilterTypeEnum } from '../../../lib/types';
+import { FilterFormContainer } from '../../../lib/components/FilterFormContainer';
 
 export interface IExpertsViewProps {}
 
@@ -61,12 +61,12 @@ const ExpertsView: React.FC<IExpertsViewProps> = () => {
       <Container fixed>
         {expertsPropertiesLoaded && (
           <Grid container>
-            <FilterForm
+            <FilterFormContainer
               setFilter={setExpertsRegionsFilter}
               filterProperties={regions}
               filterType={FilterTypeEnum.REGIONS}
             />
-            <FilterForm
+            <FilterFormContainer
               setFilter={setExpertsDirectionsFilter}
               filterProperties={directions}
               filterType={FilterTypeEnum.DIRECTIONS}


### PR DESCRIPTION
develop

## GitHub Board

**Issue link**

[#176 Make experts list's FilterForm reusable ](https://github.com/ita-social-projects/dokazovi-fe/issues/176)

## Summary of change

- [x]  Separate logic from markup in FilterForm: create FilterFormContainer and FilterForm.

