### PR TITLE
expertsSlice fix

### DIFF
--- a/src/modules/experts/store/expertsSlice.ts
+++ b/src/modules/experts/store/expertsSlice.ts
@@ -96,6 +96,9 @@ export const fetchExperts = createAsyncThunk(
       ?.value as ICheckboxes;
 
     const getTrueValues = (filterValues: ICheckboxes) => {
+      if (Object.values(filterValues).every((value) => value === true)) {
+        return [];
+      }
       return Object.keys(filterValues).filter((key) => filterValues[key]);
     };
 


### PR DESCRIPTION
develop

## GitHub Board

**Issue link**

[#201 expertsSlice: fix fetchExperts ](https://github.com/ita-social-projects/dokazovi-fe/issues/201 )

## Summary of change

- [x]  fix expertsSlice: if all filterValues are true, fetchExperts sends request without filter's properties