### PR TITLE
fix: history push state

### DIFF
--- a/src/modules/postCreation/ArticleCreation.tsx
+++ b/src/modules/postCreation/ArticleCreation.tsx
@@ -88,7 +88,7 @@ const ArticleCreation: React.FC = () => {
   const goArticlePreview = () => {
     history.push(`/create-article/preview`, {
       postType: 'ARTICLE',
-      publishPost: publishNewArticle,
+      publishPost: newPost,
     });
   };
 

--- a/src/modules/postCreation/ArticleCreation.tsx
+++ b/src/modules/postCreation/ArticleCreation.tsx
@@ -81,10 +81,6 @@ const ArticleCreation: React.FC = () => {
     history.push(`/posts/${responsePost.data.id}`);
   };
 
-  const publishNewArticle = () => {
-    sendPost(); // todo add spinner to Publish button
-  };
-
   const goArticlePreview = () => {
     history.push(`/create-article/preview`, {
       postType: 'ARTICLE',
@@ -130,7 +126,7 @@ const ArticleCreation: React.FC = () => {
       </Box>
       <Box display="flex" justifyContent="flex-end">
         <PostCreationButtons
-          publishPost={publishNewArticle}
+          publishPost={sendPost}
           goPreview={goArticlePreview}
         />
       </Box>

--- a/src/modules/postCreation/NoteCreation.tsx
+++ b/src/modules/postCreation/NoteCreation.tsx
@@ -61,10 +61,6 @@ const NoteCreation: React.FC = () => {
     history.push(`/posts/${responsePost.data.id}`);
   };
 
-  const publishNewNote = () => {
-    sendPost();
-  };
-
   const goNotePreview = () => {
     history.push(`/create-note/preview`, {
       postType: 'DOPYS',
@@ -92,10 +88,7 @@ const NoteCreation: React.FC = () => {
         <NoteEditor dispatchContent={dispatchHtmlContent} />
       </Box>
       <Box display="flex" justifyContent="flex-end">
-        <PostCreationButtons
-          publishPost={publishNewNote}
-          goPreview={goNotePreview}
-        />
+        <PostCreationButtons publishPost={sendPost} goPreview={goNotePreview} />
       </Box>
     </Container>
   );

--- a/src/modules/postCreation/NoteCreation.tsx
+++ b/src/modules/postCreation/NoteCreation.tsx
@@ -68,7 +68,7 @@ const NoteCreation: React.FC = () => {
   const goNotePreview = () => {
     history.push(`/create-note/preview`, {
       postType: 'DOPYS',
-      publishPost: publishNewNote,
+      publishPost: newPost,
     });
   };
 

--- a/src/modules/postCreation/PostCreationPreview.tsx
+++ b/src/modules/postCreation/PostCreationPreview.tsx
@@ -8,10 +8,12 @@ import { IPost, PostTypeEnum } from '../../lib/types';
 import { useStyles } from './styles/PostCreationPreview.styles';
 import { mockPost } from '../posts/mockPost/mockPost';
 import PostCreationButtons from '../../lib/components/PostCreationButtons/PostCreationButtons';
+import { PostPostRequestType } from '../../lib/utilities/API/types';
+import { postPublishPost } from '../../lib/utilities/API/api';
 
 export interface ILocationState {
   postType: string;
-  publishPost: () => void;
+  publishPost: PostPostRequestType;
 }
 
 const PostCreationPreview: React.FC = () => {
@@ -50,11 +52,20 @@ const PostCreationPreview: React.FC = () => {
     history.goBack();
   };
 
+  const sendPost = async () => {
+    const responsePost = await postPublishPost(currentState.publishPost);
+    history.push(`/posts/${responsePost.data.id}`);
+  };
+
+  const publishNewPost = () => {
+    sendPost();
+  };
+
   return (
     <Container className={classes.root}>
       <PostView post={post} />
       <PostCreationButtons
-        publishPost={currentState.publishPost}
+        publishPost={publishNewPost}
         goPreview={goBackToCreation}
         isOnPreview
       />

--- a/src/modules/postCreation/PostCreationPreview.tsx
+++ b/src/modules/postCreation/PostCreationPreview.tsx
@@ -57,15 +57,11 @@ const PostCreationPreview: React.FC = () => {
     history.push(`/posts/${responsePost.data.id}`);
   };
 
-  const publishNewPost = () => {
-    sendPost();
-  };
-
   return (
     <Container className={classes.root}>
       <PostView post={post} />
       <PostCreationButtons
-        publishPost={publishNewPost}
+        publishPost={sendPost}
         goPreview={goBackToCreation}
         isOnPreview
       />


### PR DESCRIPTION
Fix history pushState on ArticleCreation and NoteCreation

## GitHub Board

## Summary of change

- [x]  Send newPost object to the preview instead of the func
