### PR TITLE
Issue 237 directions remove page number

### DIFF
--- a/src/modules/direction/components/MaterialsContainer.tsx
+++ b/src/modules/direction/components/MaterialsContainer.tsx
@@ -27,12 +27,12 @@ const MaterialsContainer: React.FC<IMaterialsContainerProps> = ({
 }) => {
   const classes = useStyles();
   const history = useHistory();
-  const location = useLocation();
   const query = useQuery();
 
   const {
     postIds,
     meta: { loading, isLastPage, pageNumber },
+    filters,
   } = useSelector(
     (state: RootStateType) => state.directions[direction.name].materials,
   );
@@ -41,19 +41,14 @@ const MaterialsContainer: React.FC<IMaterialsContainerProps> = ({
   const dispatch = useDispatch();
 
   const dispatchFetchAction = (
-    page = Number(query.get('page')),
     checked = query.get('types')?.split(','),
     replacePosts = false,
   ) => {
-    dispatch(fetchMaterials(direction, checked, page, replacePosts));
+    dispatch(fetchMaterials(direction, checked, replacePosts));
   };
 
   const fetchMorePosts = () => {
-    const nextPage = Number(query.get('page')) + 1;
-    query.set('page', String(nextPage));
-    history.push(`${location.pathname}?${query.toString()}`);
-
-    dispatchFetchAction(nextPage);
+    dispatchFetchAction();
   };
 
   useEffect(() => {
@@ -69,8 +64,8 @@ const MaterialsContainer: React.FC<IMaterialsContainerProps> = ({
   useEffectExceptOnMount(() => {
     // page and types values are initialized from current query.
     // this call will replace current post ids with fetched ones.
-    dispatchFetchAction(undefined, undefined, true);
-  }, [query.get('types')]);
+    dispatchFetchAction(undefined, true);
+  }, [query.get('types'), filters]);
 
   // don't clear query params when returning to previous filter in url from
   // another view.
@@ -82,7 +77,6 @@ const MaterialsContainer: React.FC<IMaterialsContainerProps> = ({
 
   const setFilters = (checked: string[] = []) => {
     query.set('types', checked.join(','));
-    query.delete('page');
     if (checked.length === 0) query.delete('types');
 
     history.push({

--- a/src/modules/direction/store/directionSlice.ts
+++ b/src/modules/direction/store/directionSlice.ts
@@ -240,10 +240,13 @@ export const fetchExperts = (
 export const fetchMaterials = (
   direction: IDirection,
   postTypes: string[] = [],
-  pageNumber: number,
   replacePosts: boolean,
 ): AppThunkType => async (dispatch, getState) => {
-  const { postIds, filters } = getState().directions[direction.name].materials;
+  const {
+    postIds,
+    filters,
+    meta: { pageNumber },
+  } = getState().directions[direction.name].materials;
   const postTags = filters?.[FilterTypeEnum.TAGS]?.value as string[];
 
   try {
@@ -257,7 +260,7 @@ export const fetchMaterials = (
     const response = await getPosts('latest-by-direction', {
       params: {
         direction: direction.id,
-        page: pageNumber,
+        page: replacePosts ? -1 : pageNumber + 1,
         size: LOAD_POSTS_LIMIT,
         type: postTypes,
         tag: postTags,


### PR DESCRIPTION
develop

[#237 directions remove page number ](https://github.com/ita-social-projects/dokazovi-fe/issues/237)

## Summary of issue

- [x] Remove page arg from **fetchMaterials** thunk, use **pageNumber** from **Redux** instead.
- [x]  Update **MaterialsContainer** - remove code that gets/sets 'page' query param.
- [x] Dispatch **setFilters** action to reset page number on filter change.

## Summary of change

- [x]  Removed query params from MaterialsContainer.tsx
- [x]  Removed page arg  from directionSlice.ts
- [x]  fixed bug with tags
