### PR TITLE
Experts: Directions / regions filter + page number in URL #239

### DIFF
--- a/src/lib/components/CheckBoxFilterContainer.tsx
+++ b/src/lib/components/CheckBoxFilterContainer.tsx
@@ -1,0 +1,184 @@
+import React, { useEffect, useState } from 'react';
+import { isEmpty, mapValues } from 'lodash';
+import {
+  Accordion,
+  AccordionDetails,
+  AccordionSummary,
+  Box,
+  Checkbox,
+  FormControlLabel,
+  FormGroup,
+  Grid,
+  Typography,
+} from '@material-ui/core';
+import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
+import ChipsList from './ChipsList';
+import { ICheckBoxFormState } from './CheckBoxFilterForm';
+import { FilterTypeEnum } from '../types';
+
+interface IFilter {
+  id: string | number;
+  name: string;
+}
+
+export interface ICheckBoxFilterContainerProps {
+  onFormChange: (checked: ICheckBoxFormState, filterType?) => void;
+  possibleFilters: IFilter[];
+  selectedFilters?: IFilter[];
+  filterTitle: string;
+  filterType?: FilterTypeEnum;
+}
+
+const CheckBoxFilterFormContainer: React.FC<ICheckBoxFilterContainerProps> = ({
+  onFormChange,
+  possibleFilters,
+  selectedFilters,
+  filterTitle,
+  filterType,
+}) => {
+  const isInitialStateEmpty = isEmpty(selectedFilters);
+
+  const getCheckedStateFromFilters = (): ICheckBoxFormState => {
+    return possibleFilters.reduce((acc, next) => {
+      acc[next.id] =
+        allChecked ||
+        Boolean(selectedFilters?.find((filter) => filter.id === next.id));
+      return acc;
+    }, {} as ICheckBoxFormState);
+  };
+
+  const [allChecked, setAllChecked] = useState(isInitialStateEmpty);
+  const [checked, setChecked] = useState<ICheckBoxFormState>(
+    getCheckedStateFromFilters(),
+  );
+
+  useEffect(() => {
+    setChecked(getCheckedStateFromFilters());
+  }, [selectedFilters]);
+
+  useEffect(() => {
+    if (Object.values(checked).every((elem) => elem)) {
+      setAllChecked(true);
+    }
+  }, [checked]);
+
+  const onCheckboxCheck = (event: React.ChangeEvent<HTMLInputElement>) => {
+    if (!event.target.checked && allChecked) {
+      setAllChecked(false);
+    }
+
+    onFormChange(
+      {
+        ...checked,
+        [event.target.name]: event.target.checked,
+      },
+      filterType,
+    );
+  };
+
+  const onCheckboxAllChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const checkedFilters = event.target.checked
+      ? mapValues(checked, () => true)
+      : mapValues(checked, () => false);
+
+    setAllChecked(event.target.checked);
+    setChecked(checkedFilters);
+    onFormChange(checkedFilters, filterType);
+  };
+
+  const getNames = () => {
+    if (allChecked) {
+      return 'Всі';
+    }
+    if (selectedFilters) {
+      const names = selectedFilters?.reduce((acc, filter) => {
+        acc.push(filter.name);
+        return acc;
+      }, [] as string[]);
+      if (names?.length < 4) {
+        return names.join(', ');
+      }
+      return `${names?.slice(0, 3).join(', ')} + ${names?.length - 3}`;
+    }
+    return possibleFilters
+      .reduce((acc, filter) => {
+        acc.push(filter.name);
+        return acc;
+      }, [] as string[])
+      .join(', ');
+  };
+
+  const checkBoxes = possibleFilters?.map((filter) => {
+    const id = filter.id.toString();
+    return (
+      <FormControlLabel
+        key={id}
+        label={filter.name}
+        control={
+          <Checkbox
+            checked={checked[id]}
+            onChange={(event) => onCheckboxCheck(event)}
+            name={id}
+            color="primary"
+          />
+        }
+      />
+    );
+  });
+
+  return (
+    <>
+      <Box mt={2}>
+        <Accordion>
+          <AccordionSummary
+            expandIcon={<ExpandMoreIcon />}
+            aria-controls="panel1bh-content"
+            id="panel1bh-header"
+          >
+            <Grid container>
+              <Grid item xs={2} style={{ marginRight: '-30px' }}>
+                <Typography variant="h5">{filterTitle}</Typography>
+              </Grid>
+              <Grid item xs={10}>
+                <ChipsList checkedNames={getNames()} />
+              </Grid>
+            </Grid>
+          </AccordionSummary>
+          <AccordionDetails>
+            <Grid container>
+              <Grid item xs={2} style={{ marginRight: '-30px' }} />
+              <Grid item xs={10}>
+                <FormControlLabel
+                  style={{ width: '100%' }}
+                  control={
+                    <Checkbox
+                      id="All"
+                      checked={allChecked}
+                      onChange={onCheckboxAllChange}
+                      name="All"
+                    />
+                  }
+                  label="Всі"
+                  key="All"
+                />
+              </Grid>
+              <Grid item xs={2} style={{ marginRight: '-30px' }} />
+              <FormGroup
+                style={{
+                  height: '450px',
+                  display: 'flex',
+                  flexDirection: 'column',
+                  flexWrap: 'wrap',
+                }}
+              >
+                {checkBoxes}
+              </FormGroup>
+            </Grid>
+          </AccordionDetails>
+        </Accordion>
+      </Box>
+    </>
+  );
+};
+
+export default CheckBoxFilterFormContainer;

--- a/src/lib/components/СheckBoxDropdownFilterForm.tsx
+++ b/src/lib/components/СheckBoxDropdownFilterForm.tsx
@@ -113,7 +113,7 @@ const CheckBoxDropdownFilterForm: React.FC<ICheckBoxDropdownFilterFormProps> = (
     return (
       <FormControlLabel
         key={id}
-        label={filter.name}
+        label={<ChipsList checkedNames={filter.name} isLabelItem />}
         control={
           <Checkbox
             checked={checked[id]}

--- a/src/lib/components/СheckBoxDropdownFilterForm.tsx
+++ b/src/lib/components/СheckBoxDropdownFilterForm.tsx
@@ -21,7 +21,7 @@ interface IFilter {
   name: string;
 }
 
-export interface ICheckBoxFilterContainerProps {
+export interface ICheckBoxDropdownFilterFormProps {
   onFormChange: (checked: ICheckBoxFormState, filterType?) => void;
   possibleFilters: IFilter[];
   selectedFilters?: IFilter[];
@@ -29,7 +29,7 @@ export interface ICheckBoxFilterContainerProps {
   filterType?: FilterTypeEnum;
 }
 
-const CheckBoxFilterFormContainer: React.FC<ICheckBoxFilterContainerProps> = ({
+const CheckBoxDropdownFilterForm: React.FC<ICheckBoxDropdownFilterFormProps> = ({
   onFormChange,
   possibleFilters,
   selectedFilters,
@@ -181,4 +181,4 @@ const CheckBoxFilterFormContainer: React.FC<ICheckBoxFilterContainerProps> = ({
   );
 };
 
-export default CheckBoxFilterFormContainer;
+export default CheckBoxDropdownFilterForm;

--- a/src/lib/components/СheckBoxDropdownFilterForm.tsx
+++ b/src/lib/components/СheckBoxDropdownFilterForm.tsx
@@ -41,7 +41,7 @@ const CheckBoxDropdownFilterForm: React.FC<ICheckBoxDropdownFilterFormProps> = (
   const getCheckedStateFromFilters = (): ICheckBoxFormState => {
     return possibleFilters.reduce((acc, next) => {
       acc[next.id] =
-        allChecked ||
+        isInitialStateEmpty ||
         Boolean(selectedFilters?.find((filter) => filter.id === next.id));
       return acc;
     }, {} as ICheckBoxFormState);
@@ -53,14 +53,16 @@ const CheckBoxDropdownFilterForm: React.FC<ICheckBoxDropdownFilterFormProps> = (
   );
 
   useEffect(() => {
+    if (
+      selectedFilters === undefined ||
+      selectedFilters?.length === possibleFilters.length
+    ) {
+      setAllChecked(true);
+    } else {
+      setAllChecked(false);
+    }
     setChecked(getCheckedStateFromFilters());
   }, [selectedFilters]);
-
-  useEffect(() => {
-    if (Object.values(checked).every((elem) => elem)) {
-      setAllChecked(true);
-    }
-  }, [checked]);
 
   const onCheckboxCheck = (event: React.ChangeEvent<HTMLInputElement>) => {
     if (!event.target.checked && allChecked) {

--- a/src/modules/experts/components/ExpertsView.tsx
+++ b/src/modules/experts/components/ExpertsView.tsx
@@ -79,7 +79,6 @@ const ExpertsView: React.FC = () => {
     if (!checkedIds.length || isQuerySame) {
       query.delete(queryType);
     }
-
     query.set(PAGE_QUERY, '1');
     history.push({
       search: query.toString(),

--- a/src/modules/experts/components/ExpertsView.tsx
+++ b/src/modules/experts/components/ExpertsView.tsx
@@ -4,12 +4,7 @@ import { useHistory, useLocation } from 'react-router-dom';
 import { Box, Grid } from '@material-ui/core';
 import { useDispatch, useSelector } from 'react-redux';
 import { Pagination } from '@material-ui/lab';
-import {
-  fetchExperts,
-  setExpertsDirectionsFilter,
-  setExpertsPage,
-  setExpertsRegionsFilter,
-} from '../store/expertsSlice';
+import { fetchExperts, setExpertsPage } from '../store/expertsSlice';
 import { RootStateType } from '../../../store/rootReducer';
 import ExpertsList from '../../../lib/components/ExpertsList';
 import LoadingInfo from '../../../lib/components/LoadingInfo';
@@ -55,21 +50,21 @@ const ExpertsView: React.FC = () => {
     const directionsQuery = query.get(DIRECTIONS_QUERY);
 
     const isPage = pageQuery ? pageQuery - 1 : 0;
+    const regionsFilterQuery = regionsQuery
+      ? regionsQuery.split(',').filter(Number)
+      : [];
+    const directionsFilterQuery = directionsQuery
+      ? directionsQuery.split(',').filter(Number)
+      : [];
+
     dispatch(setExpertsPage(isPage));
-
-    const regionsType = {};
-    regionsQuery?.split(',').forEach((el) => {
-      regionsType[el] = true;
-    });
-    dispatch(setExpertsRegionsFilter({ value: regionsType }));
-
-    const directionsType = {};
-    directionsQuery?.split(',').forEach((el) => {
-      directionsType[el] = true;
-    });
-    dispatch(setExpertsDirectionsFilter({ value: directionsType }));
-
-    dispatch(fetchExperts());
+    dispatch(
+      fetchExperts({
+        page: isPage,
+        regions: regionsFilterQuery,
+        directions: directionsFilterQuery,
+      }),
+    );
   };
 
   const setFilters = (

--- a/src/modules/experts/components/ExpertsView.tsx
+++ b/src/modules/experts/components/ExpertsView.tsx
@@ -1,4 +1,6 @@
 import React, { useEffect } from 'react';
+import { isEmpty } from 'lodash';
+import { useHistory, useLocation } from 'react-router-dom';
 import { Box, Grid } from '@material-ui/core';
 import { useSelector, useDispatch } from 'react-redux';
 import { Pagination } from '@material-ui/lab';
@@ -13,12 +15,25 @@ import ExpertsList from '../../../lib/components/ExpertsList';
 import LoadingInfo from '../../../lib/components/LoadingInfo';
 import { useStyles } from '../styles/ExpertsView.styles';
 import { FilterTypeEnum } from '../../../lib/types';
-import { FilterFormContainer } from '../../../lib/components/FilterFormContainer';
 import { selectExpertsByIds } from '../../../store/selectors';
+import { ICheckBoxFormState } from '../../../lib/components/CheckBoxFilterForm';
+import CheckBoxFilterFormContainer from '../../../lib/components/CheckBoxFilterContainer';
+import useEffectExceptOnMount from '../../../lib/hooks/useEffectExceptOnMount';
+
+const useQuery = () => {
+  return new URLSearchParams(useLocation().search);
+};
+
+const PAGE_QUERY = 'page';
+const REGIONS_QUERY = 'regions';
+const DIRECTIONS_QUERY = 'directions';
 
 const ExpertsView: React.FC = () => {
   const classes = useStyles();
+  const query = useQuery();
+  const history = useHistory();
   const dispatch = useDispatch();
+
   const {
     expertIds,
     meta: { totalPages, pageNumber, loading },
@@ -35,44 +50,104 @@ const ExpertsView: React.FC = () => {
     (state: RootStateType) => state.properties?.directions,
   );
 
-  const expertsPropertiesLoaded = !!regions.length && !!directions.length;
+  const fetchMaterials = () => {
+    const pageQuery = Number(query.get(PAGE_QUERY));
+    const regionsQuery = query.get(REGIONS_QUERY);
+    const DirectionsQuery = query.get(DIRECTIONS_QUERY);
 
-  const handlePageChange = (_, page: number) => {
-    if (page === 1) {
-      dispatch(setExpertsPage(0));
+    const isPage = pageQuery ? pageQuery - 1 : 0;
+    dispatch(setExpertsPage(isPage));
+
+    const regionsType = {};
+    regionsQuery?.split(',').forEach((el) => {
+      regionsType[el] = true;
+    });
+    dispatch(setExpertsRegionsFilter({ value: regionsType }));
+
+    const directionsType = {};
+    DirectionsQuery?.split(',').forEach((el) => {
+      directionsType[el] = true;
+    });
+    dispatch(setExpertsDirectionsFilter({ value: directionsType }));
+
+    dispatch(fetchExperts());
+  };
+
+  const setFilters = (
+    checked: ICheckBoxFormState,
+    filterType: FilterTypeEnum,
+  ) => {
+    const checkedIds = Object.keys(checked).filter((key) => checked[key]);
+    const queryType = filterType.toLowerCase();
+
+    query.set(queryType, checkedIds.join(','));
+    if (!checkedIds.length) {
+      query.delete(queryType);
     } else {
-      dispatch(setExpertsPage(page - 1));
+      query.set(queryType, checkedIds.join(','));
     }
+    query.set(PAGE_QUERY, '1');
+    history.push({
+      search: query.toString(),
+    });
+  };
+
+  const handlePageChange = (_, newPage: number) => {
+    query.set(PAGE_QUERY, String(newPage));
+    history.push({
+      search: query.toString(),
+    });
   };
 
   useEffect(() => {
-    dispatch(setExpertsPage(0));
+    fetchMaterials();
   }, []);
 
-  useEffect(() => {
-    const setExperts = () => dispatch(fetchExperts());
-    setExperts();
-  }, [pageNumber]);
+  useEffectExceptOnMount(() => {
+    fetchMaterials();
+  }, [
+    query.get(PAGE_QUERY),
+    query.get(REGIONS_QUERY),
+    query.get(DIRECTIONS_QUERY),
+  ]);
 
-  useEffect(() => {
-    dispatch(fetchExperts());
-  }, [filters?.REGIONS.value, filters?.DIRECTIONS.value]);
+  const expertsPropertiesLoaded = !!regions.length && !!directions.length;
 
   const correctPageNumber = pageNumber === 0 ? 1 : pageNumber + 1;
+
+  const selectedRegionsString = query.get(REGIONS_QUERY)?.split(',');
+  const selectedDirectionsString = query.get(DIRECTIONS_QUERY)?.split(',');
+
+  const selectedRegionsFilter = regions?.filter((post) =>
+    selectedRegionsString?.includes(post.id.toString()),
+  );
+  const selectedDirectionsFilter = directions?.filter((post) =>
+    selectedDirectionsString?.includes(post.id.toString()),
+  );
+
+  const initialRegionsFilter = !isEmpty(selectedRegionsFilter)
+    ? selectedRegionsFilter
+    : undefined;
+  const initialDirectionsFilter = !isEmpty(selectedDirectionsString)
+    ? selectedDirectionsFilter
+    : undefined;
 
   return (
     <>
       {expertsPropertiesLoaded && (
         <Grid container direction="column">
-          <FilterFormContainer
-            setFilter={setExpertsRegionsFilter}
-            filterProperties={regions}
+          <CheckBoxFilterFormContainer
+            onFormChange={setFilters}
+            possibleFilters={regions}
+            selectedFilters={initialRegionsFilter}
+            filterTitle="Регіони: "
             filterType={FilterTypeEnum.REGIONS}
           />
-
-          <FilterFormContainer
-            setFilter={setExpertsDirectionsFilter}
-            filterProperties={directions}
+          <CheckBoxFilterFormContainer
+            onFormChange={setFilters}
+            possibleFilters={directions}
+            selectedFilters={initialDirectionsFilter}
+            filterTitle="Напрямки: "
             filterType={FilterTypeEnum.DIRECTIONS}
           />
         </Grid>

--- a/src/modules/experts/store/expertsSlice.ts
+++ b/src/modules/experts/store/expertsSlice.ts
@@ -98,9 +98,10 @@ export const fetchExperts = createAsyncThunk(
       ?.value as ICheckboxes;
 
     const getTrueValues = (filterValues: ICheckboxes) => {
-      if (Object.values(filterValues).every((value) => value === true)) {
-        return [];
-      }
+      // if (Object.values(filterValues).every((value) => value === true)) {
+      //   return [];
+      // }
+      // console.log(Object.keys(filterValues).filter((key) => filterValues[key]));
       return Object.keys(filterValues).filter((key) => filterValues[key]);
     };
 

--- a/src/modules/experts/store/expertsSlice.ts
+++ b/src/modules/experts/store/expertsSlice.ts
@@ -98,10 +98,6 @@ export const fetchExperts = createAsyncThunk(
       ?.value as ICheckboxes;
 
     const getTrueValues = (filterValues: ICheckboxes) => {
-      // if (Object.values(filterValues).every((value) => value === true)) {
-      //   return [];
-      // }
-      // console.log(Object.keys(filterValues).filter((key) => filterValues[key]));
       return Object.keys(filterValues).filter((key) => filterValues[key]);
     };
 

--- a/src/modules/experts/store/expertsSlice.ts
+++ b/src/modules/experts/store/expertsSlice.ts
@@ -4,7 +4,6 @@ import {
   IFilter,
   LoadingStatusEnum,
   FilterTypeEnum,
-  ICheckboxes,
   UrlFilterTypes,
 } from '../../../lib/types';
 import {
@@ -22,13 +21,6 @@ import {
   mapFetchedPosts,
 } from '../../../store/dataSlice';
 import { RequestParamsType } from '../../../lib/utilities/API/types';
-
-interface IExpertsListPayload extends IExpertPayload {
-  filters?: {
-    [FilterTypeEnum.DIRECTIONS]: IFilter;
-    [FilterTypeEnum.REGIONS]: IFilter;
-  };
-}
 
 interface IMaterialsState extends Record<string, IMaterialsPayload> {}
 
@@ -61,7 +53,7 @@ const materialsInitialState: IMaterialsPayload = {
 };
 
 export interface IExpertsState {
-  experts: IExpertsListPayload;
+  experts: IExpertPayload;
   materials: IMaterialsState;
 }
 
@@ -74,38 +66,26 @@ const initialState: IExpertsState = {
       loading: LoadingStatusEnum.idle,
       error: null,
     },
-    filters: {
-      [FilterTypeEnum.DIRECTIONS]: {
-        value: [],
-      },
-      [FilterTypeEnum.REGIONS]: {
-        value: [],
-      },
-    },
   },
   materials: {} as IMaterialsState,
 };
 
+interface IFetchExpertsOptions {
+  page: number;
+  regions: string[];
+  directions: string[];
+}
+
 export const fetchExperts = createAsyncThunk(
   'experts/loadExperts',
-  async (__, { dispatch, getState }) => {
-    const {
-      experts: { experts },
-    } = getState() as RootStateType;
-
-    const regionsFilterValues = experts.filters?.REGIONS?.value as ICheckboxes;
-    const directionsFilterValues = experts.filters?.DIRECTIONS
-      ?.value as ICheckboxes;
-
-    const getTrueValues = (filterValues: ICheckboxes) => {
-      return Object.keys(filterValues).filter((key) => filterValues[key]);
-    };
+  async (options: IFetchExpertsOptions, { dispatch, getState }) => {
+    const { page, regions, directions } = options;
 
     const { data } = await getAllExperts({
       params: {
-        page: experts.meta?.pageNumber,
-        regions: getTrueValues(regionsFilterValues),
-        directions: getTrueValues(directionsFilterValues),
+        page,
+        regions,
+        directions,
       },
     });
     dispatch(loadExperts(data.content));
@@ -147,16 +127,6 @@ export const expertsSlice = createSlice({
     },
     setExpertsPage: (state, action: PayloadAction<number>) => {
       state.experts.meta.pageNumber = action.payload;
-    },
-    setExpertsRegionsFilter: (state, action: PayloadAction<IFilter>) => {
-      if (state.experts.filters) {
-        state.experts.filters.REGIONS = action.payload;
-      }
-    },
-    setExpertsDirectionsFilter: (state, action: PayloadAction<IFilter>) => {
-      if (state.experts.filters) {
-        state.experts.filters.DIRECTIONS = action.payload;
-      }
     },
     loadMaterials: (
       state,
@@ -224,8 +194,6 @@ export const expertsSlice = createSlice({
 });
 
 export const {
-  setExpertsRegionsFilter,
-  setExpertsDirectionsFilter,
   setupExpertMaterialsID,
   loadMaterials,
   setMaterialsLoadingStatus,


### PR DESCRIPTION
develop

## GitHub Board

https://github.com/ita-social-projects/dokazovi-fe/issues/239

[Experts: Directions / regions filter + page number in URL #239 ]( https://github.com/ita-social-projects/dokazovi-fe/issues/239 )

## Summary of issue

- [x]   See changes in PR #216
- [x]   ExpertsView should use useQuery hook to store filters and page number as query params.
- [x]  fetchExperts should use these params.


## Summary of change

- [x]  Changed ExpertView behavior
- [x]  Created new Component
- [x]  Refined ExpertsSlice

