### PR TITLE
Issue 299 admin delete post

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "axios": "^0.21.0",
     "dompurify": "^2.2.6",
     "lodash": "^4.17.20",
+    "notistack": "^1.0.5",
     "qs": "^6.9.4",
     "quill": "^1.3.7",
     "quill-image-resize-module-react": "^3.0.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import React, { Suspense, useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { BrowserRouter } from 'react-router-dom';
+import { SnackbarProvider } from 'notistack';
 import {
   CircularProgress,
   CssBaseline,
@@ -43,16 +44,25 @@ const App: React.FC = () => {
   return (
     <div className="App">
       <ThemeProvider theme={MAIN_THEME}>
-        <CssBaseline />
-        <BrowserRouter>
-          <div className="content">
-            <Header />
-            <Suspense fallback={<CircularProgress className="mainLoading" />}>
-              <RenderRoutes routes={ROUTER_CONFIG} />
-            </Suspense>
-          </div>
-          <Footer />
-        </BrowserRouter>
+        <SnackbarProvider
+          maxSnack={4}
+          autoHideDuration={4000}
+          anchorOrigin={{
+            vertical: 'bottom',
+            horizontal: 'right',
+          }}
+        >
+          <CssBaseline />
+          <BrowserRouter>
+            <div className="content">
+              <Header />
+              <Suspense fallback={<CircularProgress className="mainLoading" />}>
+                <RenderRoutes routes={ROUTER_CONFIG} />
+              </Suspense>
+            </div>
+            <Footer />
+          </BrowserRouter>
+        </SnackbarProvider>
       </ThemeProvider>
     </div>
   );

--- a/src/lib/components/Modals/ConfirmModal.tsx
+++ b/src/lib/components/Modals/ConfirmModal.tsx
@@ -2,9 +2,8 @@ import React from 'react';
 import Button from '@material-ui/core/Button';
 import Dialog from '@material-ui/core/Dialog';
 import DialogActions from '@material-ui/core/DialogActions';
-import MuiDialogTitle from '@material-ui/core/DialogTitle';
-import CloseIcon from '@material-ui/icons/Close';
-import { IconButton, Typography } from '@material-ui/core';
+import DialogTitle from '@material-ui/core/DialogTitle';
+import { Box, IconButton } from '@material-ui/core';
 
 export interface IConfirmModal {
   title: string;
@@ -36,14 +35,8 @@ const AlertDialog: React.FC<IConfirmModal> = ({
         aria-labelledby="alert-dialog-title"
         aria-describedby="alert-dialog-description"
       >
-        <MuiDialogTitle disableTypography>
-          <Typography variant="h6">{title}</Typography>
-          <IconButton aria-label="close" onClick={handleClose}>
-            <CloseIcon />
-          </IconButton>
-        </MuiDialogTitle>{' '}
-        );
-        <DialogActions>
+        <DialogTitle>{title}</DialogTitle>
+        <Box display="flex" justifyContent="center">
           <Button
             onClick={() => {
               handleChoice();
@@ -56,7 +49,7 @@ const AlertDialog: React.FC<IConfirmModal> = ({
           <Button onClick={handleClose} color="primary" autoFocus>
             Ні
           </Button>
-        </DialogActions>
+        </Box>
       </Dialog>
     </div>
   );

--- a/src/lib/components/Modals/ConfirmModal.tsx
+++ b/src/lib/components/Modals/ConfirmModal.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import Button from '@material-ui/core/Button';
+import Dialog from '@material-ui/core/Dialog';
+import DialogActions from '@material-ui/core/DialogActions';
+import MuiDialogTitle from '@material-ui/core/DialogTitle';
+import CloseIcon from '@material-ui/icons/Close';
+import { IconButton, Typography } from '@material-ui/core';
+
+export interface IConfirmModal {
+  title: string;
+  icon: JSX.Element;
+  handleChoice: () => void;
+}
+
+const AlertDialog: React.FC<IConfirmModal> = ({
+  title,
+  icon,
+  handleChoice,
+}) => {
+  const [open, setOpen] = React.useState(false);
+
+  const handleClickOpen = () => {
+    setOpen(true);
+  };
+
+  const handleClose = () => {
+    setOpen(false);
+  };
+
+  return (
+    <div>
+      <IconButton onClick={handleClickOpen}>{icon}</IconButton>
+      <Dialog
+        open={open}
+        onClose={handleClose}
+        aria-labelledby="alert-dialog-title"
+        aria-describedby="alert-dialog-description"
+      >
+        <MuiDialogTitle disableTypography>
+          <Typography variant="h6">{title}</Typography>
+          <IconButton aria-label="close" onClick={handleClose}>
+            <CloseIcon />
+          </IconButton>
+        </MuiDialogTitle>{' '}
+        );
+        <DialogActions>
+          <Button
+            onClick={() => {
+              handleChoice();
+              setOpen(false);
+            }}
+            color="primary"
+          >
+            Так
+          </Button>
+          <Button onClick={handleClose} color="primary" autoFocus>
+            Ні
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </div>
+  );
+};
+
+export default AlertDialog;

--- a/src/modules/postCreation/components/PostCreationButtons.tsx
+++ b/src/modules/postCreation/components/PostCreationButtons.tsx
@@ -19,6 +19,7 @@ const PostCreationButtons: React.FC<IPostCreationButtonsProps> = ({
   const buttonText = isOnPreview
     ? 'Назад до редагування'
     : 'Попередній перегляд';
+  console.log(isDone);
 
   return (
     <>
@@ -31,7 +32,11 @@ const PostCreationButtons: React.FC<IPostCreationButtonsProps> = ({
           {buttonText}
         </Button>
         <Button disabled={!isDone} variant="contained" onClick={publishPost}>
-          {isDone ? 'Опублікувати' : <CircularProgress size={20} />}
+          {isDone === undefined || isDone ? (
+            'Опублікувати'
+          ) : (
+            <CircularProgress size={20} />
+          )}
         </Button>
       </Box>
     </>

--- a/src/modules/postCreation/components/PostCreationButtons.tsx
+++ b/src/modules/postCreation/components/PostCreationButtons.tsx
@@ -19,7 +19,6 @@ const PostCreationButtons: React.FC<IPostCreationButtonsProps> = ({
   const buttonText = isOnPreview
     ? 'Назад до редагування'
     : 'Попередній перегляд';
-  console.log(isDone);
 
   return (
     <>

--- a/src/modules/postCreation/store/postCreationSlice.ts
+++ b/src/modules/postCreation/store/postCreationSlice.ts
@@ -5,7 +5,7 @@ import { PostTypeEnum } from '../../../lib/types';
 export interface INewPostDraft {
   topics: string[];
   title?: string;
-  isDone: boolean;
+  isDone?: boolean;
   htmlContent: string;
   preview: IPostPreview;
   videoUrl?: string;
@@ -26,20 +26,17 @@ const initialState: IPostCreationState = {
   [PostTypeEnum.ARTICLE]: {
     topics: [],
     title: '',
-    isDone: false,
     htmlContent: '',
     preview: { value: '', isManuallyChanged: false },
   },
   [PostTypeEnum.DOPYS]: {
     topics: [],
-    isDone: false,
     htmlContent: '',
     preview: { value: '', isManuallyChanged: false },
   },
   [PostTypeEnum.VIDEO]: {
     topics: [],
     title: '',
-    isDone: false,
     htmlContent: '',
     preview: { value: '', isManuallyChanged: false },
     videoUrl: '',

--- a/src/modules/posts/components/PostView.tsx
+++ b/src/modules/posts/components/PostView.tsx
@@ -13,7 +13,7 @@ export interface IPostViewProps {
 }
 
 const PostView: React.FC<IPostViewProps> = ({ post, deleteHandler }) => {
-  const role = 'admin'; //  useSelector && token
+  const role = 'admin'; //  useSelector && token  = Mock
 
   const classes = useStyles();
   const authorFullName = `${post.author.firstName} ${post.author.lastName}`;
@@ -46,15 +46,13 @@ const PostView: React.FC<IPostViewProps> = ({ post, deleteHandler }) => {
           </Box>
           <Box className={classes.controlBlock}>
             {
-              role === 'admin' ? (
-                deleteHandler ? (
-                  <ConfirmModal
-                    title={''}
-                    icon={<DeleteIcon />}
-                    handleChoice={deleteHandler}
-                  />
-                ) : null
-              ) : null
+              role === 'admin' && deleteHandler && (
+                <ConfirmModal
+                  title={`Ви дійсно хочете безповоротно видалити матеріал '${post.title}'?`}
+                  icon={<DeleteIcon />}
+                  handleChoice={deleteHandler}
+                />
+              )
               // user type admin
             }
           </Box>

--- a/src/modules/posts/components/PostView.tsx
+++ b/src/modules/posts/components/PostView.tsx
@@ -1,15 +1,20 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import { Card, Box, Typography, CardMedia } from '@material-ui/core';
+import DeleteIcon from '@material-ui/icons/Delete';
 import { useStyles } from '../styles/PostView.styles';
 import { IPost } from '../../../lib/types';
 import PageTitle from '../../../lib/components/Pages/PageTitle';
+import ConfirmModal from '../../../lib/components/Modals/ConfirmModal';
 
 export interface IPostViewProps {
   post: IPost;
+  deleteHandler?: () => void;
 }
 
-const PostView: React.FC<IPostViewProps> = ({ post }) => {
+const PostView: React.FC<IPostViewProps> = ({ post, deleteHandler }) => {
+  const role = 'admin'; //  useSelector && token
+
   const classes = useStyles();
   const authorFullName = `${post.author.firstName} ${post.author.lastName}`;
   const authorMainInstitution = post.author.mainInstitution
@@ -38,6 +43,20 @@ const PostView: React.FC<IPostViewProps> = ({ post }) => {
             <Typography variant="subtitle1" color="textSecondary">
               {authorMainInstitution}
             </Typography>
+          </Box>
+          <Box className={classes.controlBlock}>
+            {
+              role === 'admin' ? (
+                deleteHandler ? (
+                  <ConfirmModal
+                    title={''}
+                    icon={<DeleteIcon />}
+                    handleChoice={deleteHandler}
+                  />
+                ) : null
+              ) : null
+              // user type admin
+            }
           </Box>
         </Box>
         <Box className={classes.contentRoot}>

--- a/src/modules/posts/components/PostViewWrapper.tsx
+++ b/src/modules/posts/components/PostViewWrapper.tsx
@@ -29,24 +29,32 @@ const PostViewWrapper: React.FC = () => {
     }
   }, [postId]);
 
-  const deletePost = useCallback(() => {
+  const deletePost = () => {
+    if (!loadedPost) return;
     try {
       const response = Math.round(Math.random()); // Mock by status 1 =  success, 0 = error
 
       if (response === 1) {
-        enqueueSnackbar(`Видалення матеріалу пройшло успішно!`, {
-          variant: 'success',
-        });
+        enqueueSnackbar(
+          `Видалення матеріалу "${loadedPost.title}" пройшло успішно!`,
+          {
+            variant: 'success',
+          },
+        );
         history.go(-1);
       }
 
       if (response === 0) {
-        enqueueSnackbar(`Видалити матеріал не вдалося.`, { variant: 'error' });
+        enqueueSnackbar(`Видалити матеріал "${loadedPost.title}" не вдалося.`, {
+          variant: 'error',
+        });
       }
     } catch (e) {
-      enqueueSnackbar(`Видалити матеріал не вдалося.`, { variant: 'error' });
+      enqueueSnackbar(`Видалити матеріал "${loadedPost.title}" не вдалося.`, {
+        variant: 'error',
+      });
     }
-  }, []);
+  };
 
   useEffect(() => {
     fetchPost();

--- a/src/modules/posts/components/PostViewWrapper.tsx
+++ b/src/modules/posts/components/PostViewWrapper.tsx
@@ -32,7 +32,7 @@ const PostViewWrapper: React.FC = () => {
   const deletePost = () => {
     if (!loadedPost) return;
     try {
-      const response = Math.round(Math.random()); // Mock by status 1 =  success, 0 = error
+      const response = 1; // Mock by status 1 =  success
 
       if (response === 1) {
         enqueueSnackbar(
@@ -42,12 +42,6 @@ const PostViewWrapper: React.FC = () => {
           },
         );
         history.go(-1);
-      }
-
-      if (response === 0) {
-        enqueueSnackbar(`Видалити матеріал "${loadedPost.title}" не вдалося.`, {
-          variant: 'error',
-        });
       }
     } catch (e) {
       enqueueSnackbar(`Видалити матеріал "${loadedPost.title}" не вдалося.`, {

--- a/src/modules/posts/components/PostViewWrapper.tsx
+++ b/src/modules/posts/components/PostViewWrapper.tsx
@@ -25,6 +25,10 @@ const PostViewWrapper: React.FC = () => {
     }
   }, [postId]);
 
+  const deletePost = useCallback(() => {
+    console.log('hello');
+  }, []);
+
   useEffect(() => {
     fetchPost();
   }, [fetchPost]);
@@ -33,7 +37,11 @@ const PostViewWrapper: React.FC = () => {
     history.push('/error_404');
   }
 
-  return <>{loadedPost && <PostView post={loadedPost} />}</>;
+  return (
+    <>
+      {loadedPost && <PostView post={loadedPost} deleteHandler={deletePost} />}
+    </>
+  );
 };
 
 export default PostViewWrapper;

--- a/src/modules/posts/components/PostViewWrapper.tsx
+++ b/src/modules/posts/components/PostViewWrapper.tsx
@@ -1,13 +1,17 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import { useHistory, useParams } from 'react-router-dom';
+import { useSnackbar } from 'notistack';
 import { getPostById } from '../../../lib/utilities/API/api';
 import { IPost } from '../../../lib/types';
 import PostView from './PostView';
 import { sanitizeHtml } from '../../../lib/utilities/sanitizeHtml';
 
 const PostViewWrapper: React.FC = () => {
+  const { enqueueSnackbar } = useSnackbar();
+
   const { postId } = useParams<{ postId: string }>();
   const history = useHistory();
+
   const [loadedPost, setLoadedPost] = useState<IPost>();
   const [statusCode, setStatusCode] = useState<number>();
 
@@ -26,7 +30,22 @@ const PostViewWrapper: React.FC = () => {
   }, [postId]);
 
   const deletePost = useCallback(() => {
-    console.log('hello');
+    try {
+      const response = Math.round(Math.random()); // Mock by status 1 =  success, 0 = error
+
+      if (response === 1) {
+        enqueueSnackbar(`Видалення матеріалу пройшло успішно!`, {
+          variant: 'success',
+        });
+        history.go(-1);
+      }
+
+      if (response === 0) {
+        enqueueSnackbar(`Видалити матеріал не вдалося.`, { variant: 'error' });
+      }
+    } catch (e) {
+      enqueueSnackbar(`Видалити матеріал не вдалося.`, { variant: 'error' });
+    }
   }, []);
 
   useEffect(() => {

--- a/src/modules/posts/styles/PostView.styles.ts
+++ b/src/modules/posts/styles/PostView.styles.ts
@@ -19,6 +19,10 @@ export const useStyles = makeStyles(
       filter: 'grayscale(100%)',
       marginRight: theme.spacing(4),
     },
+    controlBlock: {
+      alignSelf: 'flex-start',
+      marginLeft: 'auto',
+    },
     contentRoot: {
       minHeight: '550px',
     },


### PR DESCRIPTION
develop

## GitHub Board

**Issue link**

[#299 Admin: delete posts  ](https://github.com/ita-social-projects/dokazovi-fe/issues/299 )

## Summary of issue

- [x]   show delete button on the posts page
- [x]  show confirmation modal on clicking the delete button
- [x] if YES then send the request to delete the post
- [x]  show success or fail toaster https://material-ui.com/components/snackbars/
- [x] navigate to main page on success


## Summary of change

- [x]  Implemented new ConfirmModal component
- [x]  Added functionality that will delete post
- [x] Added check for admin role 
- [x] Fixed post creation button bug