### PR TITLE
Issue 368 fix scrolling on loading new posts

### DIFF
--- a/src/old/lib/components/Experts/ExpertsList.tsx
+++ b/src/old/lib/components/Experts/ExpertsList.tsx
@@ -1,5 +1,6 @@
 import { Grid } from '@material-ui/core';
-import React from 'react';
+import React, { forwardRef } from 'react';
+import { LOAD_EXPERTS_LIMIT } from '../../constants/experts';
 import { IExpert } from '../../types';
 import ExpertPhotoDataCard from './ExpertPhotoDataCard';
 
@@ -7,16 +8,25 @@ export interface IExpertsListProps {
   experts: IExpert[];
 }
 
-export const ExpertsList: React.FC<IExpertsListProps> = (props) => {
-  const { experts } = props;
+// eslint-disable-next-line react/display-name
+export const ExpertsList = forwardRef<HTMLDivElement, IExpertsListProps>(
+  ({ experts }, nodeToScrollToRef) => {
+    const expertsToScrollIntoViewIdx = experts.length - LOAD_EXPERTS_LIMIT;
 
-  return (
-    <Grid container spacing={3}>
-      {experts.map((expert) => (
-        <Grid item md={4} lg={4} key={expert.id}>
-          <ExpertPhotoDataCard expert={expert} key={expert.id} />
-        </Grid>
-      ))}
-    </Grid>
-  );
-};
+    return (
+      <Grid container spacing={3}>
+        {experts.map((expert, idx) => (
+          <Grid
+            item
+            md={4}
+            lg={4}
+            key={expert.id}
+            ref={expertsToScrollIntoViewIdx === idx ? nodeToScrollToRef : null}
+          >
+            <ExpertPhotoDataCard expert={expert} key={expert.id} />
+          </Grid>
+        ))}
+      </Grid>
+    );
+  },
+);

--- a/src/old/lib/components/Experts/ExpertsList.tsx
+++ b/src/old/lib/components/Experts/ExpertsList.tsx
@@ -1,5 +1,5 @@
 import { Grid } from '@material-ui/core';
-import React, { forwardRef } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { LOAD_EXPERTS_LIMIT } from '../../constants/experts';
 import { IExpert } from '../../types';
 import ExpertPhotoDataCard from './ExpertPhotoDataCard';
@@ -8,25 +8,38 @@ export interface IExpertsListProps {
   experts: IExpert[];
 }
 
-// eslint-disable-next-line react/display-name
-export const ExpertsList = forwardRef<HTMLDivElement, IExpertsListProps>(
-  ({ experts }, nodeToScrollToRef) => {
-    const expertsToScrollIntoViewIdx = experts.length - LOAD_EXPERTS_LIMIT;
+export const ExpertsList: React.FC<IExpertsListProps> = ({ experts }) => {
+  const expertIdxForScroll = experts.length - LOAD_EXPERTS_LIMIT;
+  const expertForScrollRef = useRef<HTMLDivElement>(null);
 
-    return (
-      <Grid container spacing={3}>
-        {experts.map((expert, idx) => (
-          <Grid
-            item
-            md={4}
-            lg={4}
-            key={expert.id}
-            ref={expertsToScrollIntoViewIdx === idx ? nodeToScrollToRef : null}
-          >
-            <ExpertPhotoDataCard expert={expert} key={expert.id} />
-          </Grid>
-        ))}
-      </Grid>
-    );
-  },
-);
+  const [prevExpertsCount, setPrevExpertsLength] = useState(experts.length);
+
+  useEffect(() => {
+    if (!expertForScrollRef.current) return;
+    if (
+      experts.length > LOAD_EXPERTS_LIMIT &&
+      experts.length !== prevExpertsCount
+    ) {
+      expertForScrollRef.current.scrollIntoView({
+        behavior: 'smooth',
+      });
+    }
+    setPrevExpertsLength(experts.length);
+  }, [experts.length]);
+
+  return (
+    <Grid container spacing={3}>
+      {experts.map((expert, idx) => (
+        <Grid
+          item
+          md={4}
+          lg={4}
+          key={expert.id}
+          ref={expertIdxForScroll === idx ? expertForScrollRef : null}
+        >
+          <ExpertPhotoDataCard expert={expert} key={expert.id} />
+        </Grid>
+      ))}
+    </Grid>
+  );
+};

--- a/src/old/lib/components/Posts/PostsList.tsx
+++ b/src/old/lib/components/Posts/PostsList.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import Masonry from 'react-masonry-css';
 import { useStyles, MASONRY_BREAKPOINTS } from '../../styles/PostsList.styles';
 import { IPost } from '../../types';
@@ -9,28 +9,42 @@ export interface IPostsListProps {
   postsList: IPost[];
 }
 
-// eslint-disable-next-line react/display-name
-export const PostsList = forwardRef<HTMLDivElement, IPostsListProps>(
-  ({ postsList }, nodeToScrollToRef) => {
-    const classes = useStyles();
-    const postToScrollIntoViewIdx = postsList.length - LOAD_POSTS_LIMIT;
+export const PostsList: React.FC<IPostsListProps> = ({ postsList }) => {
+  const classes = useStyles();
+  const postIdxForScroll = postsList.length - LOAD_POSTS_LIMIT;
+  const postForScrollRef = useRef<HTMLDivElement>(null);
 
-    return (
-      <Masonry
-        breakpointCols={MASONRY_BREAKPOINTS}
-        className={classes.masonryGrid}
-        columnClassName={classes.masonryColumn}
-      >
-        {postsList.map((post, idx) => (
-          <div
-            key={post.id}
-            className={classes.masonryItem}
-            ref={postToScrollIntoViewIdx === idx ? nodeToScrollToRef : null}
-          >
-            <PostPreviewCard post={post} />
-          </div>
-        ))}
-      </Masonry>
-    );
-  },
-);
+  const [prevPostsCount, setPrevPostsLength] = useState(postsList.length);
+
+  useEffect(() => {
+    if (!postForScrollRef.current) return;
+    if (
+      postsList.length > LOAD_POSTS_LIMIT &&
+      postsList.length !== prevPostsCount
+    ) {
+      postForScrollRef.current.scrollIntoView({
+        behavior: 'smooth',
+      });
+    }
+
+    setPrevPostsLength(postsList.length);
+  }, [postsList.length]);
+
+  return (
+    <Masonry
+      breakpointCols={MASONRY_BREAKPOINTS}
+      className={classes.masonryGrid}
+      columnClassName={classes.masonryColumn}
+    >
+      {postsList.map((post, idx) => (
+        <div
+          key={post.id}
+          className={classes.masonryItem}
+          ref={postIdxForScroll === idx ? postForScrollRef : null}
+        >
+          <PostPreviewCard post={post} />
+        </div>
+      ))}
+    </Masonry>
+  );
+};

--- a/src/old/lib/components/Posts/PostsList.tsx
+++ b/src/old/lib/components/Posts/PostsList.tsx
@@ -1,28 +1,36 @@
-import { Box } from '@material-ui/core';
-import React from 'react';
+import React, { forwardRef } from 'react';
 import Masonry from 'react-masonry-css';
 import { useStyles, MASONRY_BREAKPOINTS } from '../../styles/PostsList.styles';
 import { IPost } from '../../types';
 import { PostPreviewCard } from '../../../../components/Posts/Cards/PostPreviewCard';
+import { LOAD_POSTS_LIMIT } from '../../constants/posts';
 
 export interface IPostsListProps {
   postsList: IPost[];
 }
 
-export const PostsList: React.FC<IPostsListProps> = ({ postsList }) => {
-  const classes = useStyles();
+// eslint-disable-next-line react/display-name
+export const PostsList = forwardRef<HTMLDivElement, IPostsListProps>(
+  ({ postsList }, nodeToScrollToRef) => {
+    const classes = useStyles();
+    const postToScrollIntoViewIdx = postsList.length - LOAD_POSTS_LIMIT;
 
-  return (
-    <Masonry
-      breakpointCols={MASONRY_BREAKPOINTS}
-      className={classes.masonryGrid}
-      columnClassName={classes.masonryColumn}
-    >
-      {postsList.map((post) => (
-        <Box key={post.id} className={classes.masonryItem}>
-          <PostPreviewCard post={post} />
-        </Box>
-      ))}
-    </Masonry>
-  );
-};
+    return (
+      <Masonry
+        breakpointCols={MASONRY_BREAKPOINTS}
+        className={classes.masonryGrid}
+        columnClassName={classes.masonryColumn}
+      >
+        {postsList.map((post, idx) => (
+          <div
+            key={post.id}
+            className={classes.masonryItem}
+            ref={postToScrollIntoViewIdx === idx ? nodeToScrollToRef : null}
+          >
+            <PostPreviewCard post={post} />
+          </div>
+        ))}
+      </Masonry>
+    );
+  },
+);

--- a/src/old/modules/experts/components/ExpertsView.tsx
+++ b/src/old/modules/experts/components/ExpertsView.tsx
@@ -147,10 +147,10 @@ const ExpertsView: React.FC = () => {
     ? selectedDirections
     : undefined;
 
-  const gridRef = useRef<HTMLDivElement>(null);
+  const nodeToScrollToRef = useRef<HTMLDivElement>(null);
   useEffectExceptOnMount(() => {
     if (page > 0) {
-      gridRef.current?.scrollIntoView({ behavior: 'smooth' });
+      nodeToScrollToRef.current?.scrollIntoView({ behavior: 'smooth' });
     }
   }, [expertIds]);
 
@@ -302,8 +302,8 @@ const ExpertsView: React.FC = () => {
             <LoadingContainer loading={loading} expand />
           ) : (
             <>
-              <ExpertsList experts={experts} />
-              <Grid container justify="center" ref={gridRef}>
+              <ExpertsList experts={experts} ref={nodeToScrollToRef} />
+              <Grid container justify="center">
                 <LoadMoreButton
                   clicked={loadMore}
                   isLastPage={isLastPage}

--- a/src/old/modules/experts/components/ExpertsView.tsx
+++ b/src/old/modules/experts/components/ExpertsView.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useHistory } from 'react-router-dom';
 import { useSelector } from 'react-redux';
 import { isEmpty, uniq } from 'lodash';
@@ -16,7 +16,6 @@ import {
 import { fetchExperts, selectExperts } from '../../../../models/experts';
 import { RootStateType } from '../../../store/rootReducer';
 import { ExpertsList } from '../../../lib/components/Experts/ExpertsList';
-import { useEffectExceptOnMount } from '../../../lib/hooks/useEffectExceptOnMount';
 import { LoadMoreButton } from '../../../lib/components/LoadMoreButton/LoadMoreButton';
 import { selectExpertsByIds } from '../../../store/selectors';
 import { CheckboxFormStateType } from '../../../lib/components/Filters/CheckboxFilterForm';
@@ -147,13 +146,6 @@ const ExpertsView: React.FC = () => {
   selectedDirections = !isEmpty(selectedDirections)
     ? selectedDirections
     : undefined;
-
-  const nodeToScrollToRef = useRef<HTMLDivElement>(null);
-  useEffectExceptOnMount(() => {
-    if (page > 0) {
-      nodeToScrollToRef.current?.scrollIntoView({ behavior: 'smooth' });
-    }
-  }, [expertIds]);
 
   const getRegions = () => {
     if (selectedRegions) {
@@ -303,7 +295,7 @@ const ExpertsView: React.FC = () => {
             <LoadingContainer loading={loading} expand />
           ) : (
             <>
-              <ExpertsList experts={experts} ref={nodeToScrollToRef} />
+              <ExpertsList experts={experts} />
               <Grid container justify="center">
                 <LoadMoreButton
                   clicked={loadMore}

--- a/src/old/modules/materials/components/MaterialsView.tsx
+++ b/src/old/modules/materials/components/MaterialsView.tsx
@@ -1,13 +1,12 @@
 /* eslint-disable @typescript-eslint/no-shadow */
 import { Grid, Typography, Box } from '@material-ui/core';
 import { isEmpty, uniq } from 'lodash';
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { useHistory } from 'react-router-dom';
 import { CheckboxFormStateType } from '../../../lib/components/Filters/CheckboxFilterForm';
 import { PostsList } from '../../../lib/components/Posts/PostsList';
 import { LoadMoreButton } from '../../../lib/components/LoadMoreButton/LoadMoreButton';
-import { useEffectExceptOnMount } from '../../../lib/hooks/useEffectExceptOnMount';
 import { usePrevious } from '../../../lib/hooks/usePrevious';
 import {
   FilterTypeEnum,
@@ -265,17 +264,6 @@ const MaterialsView: React.FC = () => {
     ? selectedPostTypes
     : undefined;
 
-  const nodeToScrollToRef = useRef<HTMLDivElement>(null);
-
-  useEffectExceptOnMount(() => {
-    if (page > 0) {
-      nodeToScrollToRef.current?.scrollIntoView({
-        behavior: 'smooth',
-        block: 'start',
-      });
-    }
-  }, [postIds]);
-
   const getOrigins = () => {
     if (selectedOrigins) {
       const names = selectedOrigins?.reduce((acc, filter) => {
@@ -478,7 +466,7 @@ const MaterialsView: React.FC = () => {
             <LoadingContainer loading={loading} expand />
           ) : (
             <>
-              <PostsList postsList={materials} ref={nodeToScrollToRef} />
+              <PostsList postsList={materials} />
               <Grid container justify="center">
                 <LoadMoreButton
                   clicked={loadMore}

--- a/src/old/modules/materials/components/MaterialsView.tsx
+++ b/src/old/modules/materials/components/MaterialsView.tsx
@@ -131,10 +131,13 @@ const MaterialsView: React.FC = () => {
     ? selectedPostTypes
     : undefined;
 
-  const gridRef = useRef<HTMLDivElement>(null);
+  const nodeToScrollToRef = useRef<HTMLDivElement>(null);
   useEffectExceptOnMount(() => {
     if (page > 0) {
-      gridRef.current?.scrollIntoView({ behavior: 'smooth' });
+      nodeToScrollToRef.current?.scrollIntoView({
+        behavior: 'smooth',
+        block: 'start',
+      });
     }
   }, [postIds]);
 
@@ -167,9 +170,9 @@ const MaterialsView: React.FC = () => {
       ) : (
         <>
           <Grid container alignItems="center" style={{ marginTop: 20 }}>
-            <PostsList postsList={materials} />
+            <PostsList postsList={materials} ref={nodeToScrollToRef} />
           </Grid>
-          <Grid container justify="center" ref={gridRef}>
+          <Grid container justify="center">
             <LoadMoreButton
               clicked={loadMore}
               isLastPage={isLastPage}


### PR DESCRIPTION
## GitHub Board

**Issue link**

[#368  Fix scrolling on loading new posts](https://github.com/ita-social-projects/dokazovi-fe/issues/368 )

**Story link**

[#244 As a user I want to load more items on the page so that I will choose necessary items for me](https://github.com/ita-social-projects/dokazovi-be/issues/244 )


## Summary of issue

- [x]  Fix scrolling into view on loading new posts in MaterialsView
- [x]  Fix scrolling into view on loading new experts in ExpertsView


## Summary of change

- [x]  Fix scrolling into view in MaterialView by adding forwardRef to MaterialsList
- [x]  Fix scrolling into view in ExpertsView by adding forwardRef to ExpertsList
