### PR TITLE
Remove intermediate display of components

### DIFF
--- a/src/models/experts/index.ts
+++ b/src/models/experts/index.ts
@@ -4,7 +4,12 @@ export {
   fetchExpertById,
   fetchExpertMaterials,
 } from './asyncActions';
-export { resetMaterials, loadPosts, expertsReducer } from './reducers';
+export {
+  resetMaterials,
+  loadPosts,
+  expertsReducer,
+  setPending,
+} from './reducers';
 export {
   selectExperts,
   selectLoadingExpertsPosts,

--- a/src/models/experts/reducers.ts
+++ b/src/models/experts/reducers.ts
@@ -2,11 +2,11 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import { IPost, LoadingStatusEnum } from '../../old/lib/types';
 import { IExpertsState } from './types';
-import { IMaterialsState } from '../materials/types';
+import { IInitialMaterialsState } from '../materials/types';
 import { fetchExpertMaterials, fetchExperts } from './asyncActions';
 import { getAsyncActionsReducer } from '../helpers/asyncActions';
 
-const initialMaterialsState: IMaterialsState = {
+const initialMaterialsState: IInitialMaterialsState = {
   data: {
     postIds: [],
     posts: {},
@@ -16,10 +16,10 @@ const initialMaterialsState: IMaterialsState = {
       totalElements: 0,
       totalPages: 0,
     },
+    loading: LoadingStatusEnum.idle,
+    error: null,
+    filters: {},
   },
-  loading: LoadingStatusEnum.idle,
-  error: null,
-  filters: {},
 };
 
 const initialState: IExpertsState = {
@@ -52,6 +52,10 @@ export const expertsSlice = createSlice({
         }
       });
     },
+    setPending: (state) => {
+      console.log('set pending');
+      state.posts.data.loading = LoadingStatusEnum.pending;
+    },
   },
   extraReducers: {
     ...getAsyncActionsReducer(fetchExperts as any),
@@ -59,6 +63,6 @@ export const expertsSlice = createSlice({
   },
 });
 
-export const { resetMaterials, loadPosts } = expertsSlice.actions;
+export const { resetMaterials, loadPosts, setPending } = expertsSlice.actions;
 
 export const expertsReducer = expertsSlice.reducer;

--- a/src/models/experts/reducers.ts
+++ b/src/models/experts/reducers.ts
@@ -53,7 +53,6 @@ export const expertsSlice = createSlice({
       });
     },
     setPending: (state) => {
-      console.log('set pending');
       state.posts.data.loading = LoadingStatusEnum.pending;
     },
   },

--- a/src/models/experts/selectors.ts
+++ b/src/models/experts/selectors.ts
@@ -13,7 +13,7 @@ export const selectExpertsData = (state: RootStateType): IMaterialsData =>
 
 export const selectLoadingExpertsPosts = (
   state: RootStateType,
-): LoadingStatusEnum => state.experts.posts.loading;
+): LoadingStatusEnum => state.experts.posts.data.loading;
 
 export const selectLoadingExperts = (state: RootStateType): LoadingStatusEnum =>
   state.experts.loading;

--- a/src/models/experts/types.ts
+++ b/src/models/experts/types.ts
@@ -1,5 +1,5 @@
 import { IExpert, LoadingStatusEnum } from '../../old/lib/types';
-import { IMaterialsState } from '../materials/types';
+import { IInitialMaterialsState } from '../materials/types';
 
 export interface IExpertsData {
   expertIds: number[];
@@ -13,7 +13,7 @@ export interface IExpertsState {
   data: IExpertsData;
   loading: LoadingStatusEnum;
   error: null | string;
-  posts: IMaterialsState;
+  posts: IInitialMaterialsState;
 }
 export interface IExpertMeta {
   totalPages: number;

--- a/src/models/materials/types.ts
+++ b/src/models/materials/types.ts
@@ -1,5 +1,22 @@
 import { IPost, LoadingStatusEnum, QueryTypeEnum } from '../../old/lib/types';
 
+export interface IInitialMaterialsState {
+  data: IInitialMaterialsData;
+}
+
+export interface IInitialMaterialsData {
+  postIds: number[];
+  meta: IMaterialsMeta;
+  posts: {
+    [id: string]: IPost;
+  };
+  loading: LoadingStatusEnum;
+  error: null | string;
+  filters?: {
+    [key in QueryTypeEnum]?: number[];
+  };
+}
+
 export interface IMaterialsData {
   postIds: number[];
   meta: IMaterialsMeta;

--- a/src/old/lib/components/Loading/LoadingContainer.styles.ts
+++ b/src/old/lib/components/Loading/LoadingContainer.styles.ts
@@ -2,16 +2,16 @@ import { makeStyles } from '@material-ui/core';
 
 export const useStyles = makeStyles(
   {
-    container: {
+    relativeContainer: {
+      marginTop: '30vh',
       flexDirection: 'column',
       alignItems: 'center',
       justifyContent: 'center',
     },
-    expandedContainer: {
+    container: {
       flexDirection: 'column',
       alignItems: 'center',
       justifyContent: 'center',
-      flexGrow: 1,
     },
   },
   { name: 'LoadingContainer' },

--- a/src/old/lib/components/Loading/LoadingContainer.tsx
+++ b/src/old/lib/components/Loading/LoadingContainer.tsx
@@ -17,7 +17,7 @@ export const LoadingContainer: React.FC<ILoadingContainerProps> = (props) => {
   return (
     <Grid
       container
-      className={expand ? classes.expandedContainer : classes.container}
+      className={expand ? classes.relativeContainer : classes.container}
     >
       <LoadingInfo loading={loading} errorMsg={errorMsg} />
     </Grid>

--- a/src/old/modules/experts/components/ExpertMaterialsContainer.tsx
+++ b/src/old/modules/experts/components/ExpertMaterialsContainer.tsx
@@ -22,7 +22,6 @@ import {
   IExpert,
   ChipFilterType,
   ChipFilterEnum,
-  IPost,
 } from '../../../lib/types';
 import {
   RequestParamsType,
@@ -50,12 +49,6 @@ import { declOfNum } from '../../utilities/declOfNum';
 export interface IExpertMaterialsContainerProps {
   expertId: number;
   expert: IExpert;
-}
-
-export interface IPosts1 {
-  posts1: {
-    [id: string]: IPost;
-  };
 }
 
 const ExpertMaterialsContainer: React.FC<IExpertMaterialsContainerProps> = ({


### PR DESCRIPTION
develop

## GitHub Board

**https://github.com/ita-social-projects/dokazovi-fe/issues/392**

[#392 Remove intermediate display of components ]( )

- [ ]  Intermediate display of components (experts page -> expert profile) removed;
- [ ] loading spinner style changed;
