### PR TITLE
Change filter section title

### DIFF
--- a/src/old/modules/experts/components/ExpertsView.tsx
+++ b/src/old/modules/experts/components/ExpertsView.tsx
@@ -326,8 +326,8 @@ const ExpertsView: React.FC = () => {
                 }
                 possibleFilters={directions}
                 selectedFilters={selectedDirections}
-                filterTitle={t(langTokens.common.byOrigin).toLowerCase()}
-                allTitle={t(langTokens.common.allOrigins)}
+                filterTitle={t(langTokens.common.byDirection).toLowerCase()}
+                allTitle={t(langTokens.common.allDirections)}
                 filterType={QueryTypeEnum.DIRECTIONS}
               />
               <CheckboxLeftsideFilterForm


### PR DESCRIPTION
develop

## GitHub Board

**Issue link**

[#454 Change filter section label in ExpertsPage ](https://github.com/ita-social-projects/dokazovi-fe/issues/454 )

## Summary of issue

- [x]  Change filter section label in ExpertsPage from origins to directions.

## Summary of change

- [x]  Changed filter section label in ExpertsPage from origins to directions.
