### PR TITLE
Fix origins, post types label names order, correct the post type label name at the Materials page

### DIFF
--- a/src/old/modules/materials/components/MaterialsView.tsx
+++ b/src/old/modules/materials/components/MaterialsView.tsx
@@ -101,7 +101,7 @@ const MaterialsView: React.FC = () => {
       value: `${t(langTokens.common.translation, defaultPlural)}`,
     });
 
-    originsInPlural.push(el1, el2, el3);
+    originsInPlural.push(el1, el3, el2);
   }
 
   const postTypes = useSelector(selectPostTypes);
@@ -117,7 +117,7 @@ const MaterialsView: React.FC = () => {
       enumerable: false,
       configurable: true,
       writable: true,
-      value: `${t(langTokens.common.article, defaultPlural)}`,
+      value: `${t(langTokens.common.article_1, defaultPlural)}`,
     });
     Object.defineProperty(el2, 'name', {
       enumerable: false,
@@ -132,7 +132,7 @@ const MaterialsView: React.FC = () => {
       value: `${t(langTokens.common.post, defaultPlural)}`,
     });
 
-    postTypesInPlural.push(el1, el2, el3);
+    postTypesInPlural.push(el1, el3, el2);
   }
 
   const directions = useSelector(selectDirections);


### PR DESCRIPTION
develop

## GitHub Board

**Story link**
[#196 Story](https://github.com/ita-social-projects/dokazovi-be/issues/196)

### Task description
Fix bug origins, post types label names order at the Materials page

## Summary of issue

- [x]  Change the order of origins types label: За джерелом: "Думки експертів", "Переклади", "Медитека".
- [x]  Change the order of post types label: За джерелом: "Статті", "Дописи", "Відео".
- [x]  Correct the post type label, change "Стаття" on "Статті". 


## Summary of change

- [x]  The order of origins types label: За джерелом: "Думки експертів", "Переклади", "Медитека" changed
- [x]  The order of post types label: За джерелом: "Статті", "Дописи", "Відео" changed
- [x]  The post type label, "Стаття" on "Статті" corrected
