### PR TITLE
Fix missing posts in MaterialView after navigating to it back.

### DIFF
--- a/src/old/modules/materials/components/MaterialsView.tsx
+++ b/src/old/modules/materials/components/MaterialsView.tsx
@@ -241,7 +241,7 @@ const MaterialsView: React.FC = () => {
   }, [page]);
 
   useEffect(() => {
-    const appendPosts = (previous && previous.page < page) || page !== 0;
+    const appendPosts = previous?.page < page || page !== 0;
     fetchData(appendPosts);
   }, [
     query.get(QueryTypeEnum.ORIGINS),

--- a/src/old/modules/materials/components/MaterialsView.tsx
+++ b/src/old/modules/materials/components/MaterialsView.tsx
@@ -241,7 +241,7 @@ const MaterialsView: React.FC = () => {
   }, [page]);
 
   useEffect(() => {
-    const appendPosts = previous && previous.page < page;
+    const appendPosts = (previous && previous.page < page) || page !== 0;
     fetchData(appendPosts);
   }, [
     query.get(QueryTypeEnum.ORIGINS),

--- a/src/old/modules/materials/components/MaterialsView.tsx
+++ b/src/old/modules/materials/components/MaterialsView.tsx
@@ -241,7 +241,7 @@ const MaterialsView: React.FC = () => {
   }, [page]);
 
   useEffect(() => {
-    const appendPosts = previous?.page < page || page !== 0;
+    const appendPosts = (previous && previous.page < page) || page !== 0;
     fetchData(appendPosts);
   }, [
     query.get(QueryTypeEnum.ORIGINS),


### PR DESCRIPTION
develop

## GitHub Board

https://github.com/ita-social-projects/dokazovi-fe/issues/379


https://github.com/ita-social-projects/dokazovi-requirements/issues/139


## Code reviewers
@sarhan-azizov 
@michalenr 

## Summary of issue

The 'Матеріали' tab contains only the materials that were displayed in last step

