### PR TITLE
Bugfix #152 wrong redirection from the material card

### DIFF
--- a/src/components/Posts/Cards/TranslationPostPreviewCard/TranslationPostPreviewCard.tsx
+++ b/src/components/Posts/Cards/TranslationPostPreviewCard/TranslationPostPreviewCard.tsx
@@ -18,7 +18,7 @@ export const TranslationPostPreviewCard: React.FC<IPostPreviewCardProps> = ({
   const bgImageURL = post.previewImageUrl ? post.previewImageUrl : background;
   const classes = useStyles({ backgroundImageUrl: bgImageURL });
   const postLink = `/posts/${post.id}`;
-  const materialsLink = `/materials?source=3`;
+  const materialsLink = `/materials?origins=3`;
   const authorFullName = `${post.author.firstName} ${post.author.lastName}`;
 
   const cardHeader = (


### PR DESCRIPTION
develop

## GitHub Board

https://github.com/ita-social-projects/dokazovi-requirements/issues/152

[Bug Report] Wrong redirection from the material card with filter "Переклади" after clicking on Author's name on the author's block.

**Story link**

https://github.com/ita-social-projects/dokazovi-be/issues/311


## Code reviewers
@michalenr 
@sarhan-azizov 
@NabokinAlexandr 

## Summary of issue

was incorrect adress
`/materials?source=3`

## Summary of change

changed to 
`/materials?origins=3`;
