### PR TITLE
fix bug with items size and accord. arrow color

### DIFF
--- a/src/models/utilities/filterConfigTypes.ts
+++ b/src/models/utilities/filterConfigTypes.ts
@@ -1,13 +1,13 @@
 import { FilterConfigType } from '../materials/types';
 
 export const allCheckedFilterConfig = [
-  { id: '1', name: 'Стаття', checked: true },
+  { id: '1', name: 'Статті', checked: true },
+  { id: '3', name: 'Дописи', checked: true },
   { id: '2', name: 'Відео', checked: true },
-  { id: '3', name: 'Допис', checked: true },
 ] as FilterConfigType[];
 
 export const allUncheckedFilterConfig = [
-  { id: '1', name: 'Стаття', checked: false },
+  { id: '1', name: 'Статті', checked: false },
+  { id: '3', name: 'Дописи', checked: false },
   { id: '2', name: 'Відео', checked: false },
-  { id: '3', name: 'Допис', checked: false },
 ] as FilterConfigType[];

--- a/src/views/Profile/MaterialsView/FilterSection.tsx
+++ b/src/views/Profile/MaterialsView/FilterSection.tsx
@@ -7,7 +7,7 @@ import {
   Grid,
   Typography,
 } from '@material-ui/core';
-import { useStyles } from '../../../old/lib/components/Filters/CheckboxLeftsideFilterForm.styles';
+import { useStyles } from './styles/FilterSection.styles';
 import { FilterConfigType } from '../../../models/materials/types';
 
 export interface IFilterSectionProps {

--- a/src/views/Profile/MaterialsView/MaterialsDraft.tsx
+++ b/src/views/Profile/MaterialsView/MaterialsDraft.tsx
@@ -181,7 +181,7 @@ const MaterialsDraft: React.FC<IMaterialsDraftProps> = ({
     >
       <AccordionSummary
         className={classes.addMaterialsHeader}
-        expandIcon={<ExpandMore />}
+        expandIcon={<ExpandMore color="secondary" />}
       >
         <h2>{t(langTokens.common.unPublishedMaterials)}</h2>
       </AccordionSummary>

--- a/src/views/Profile/MaterialsView/MaterialsPublished.tsx
+++ b/src/views/Profile/MaterialsView/MaterialsPublished.tsx
@@ -155,7 +155,7 @@ const MaterialsPublished: React.FC<IMaterialsPublishedProps> = ({
     >
       <AccordionSummary
         className={classes.addMaterialsHeader}
-        expandIcon={<ExpandMore />}
+        expandIcon={<ExpandMore color="secondary" />}
       >
         <h2>{t(langTokens.common.publishedMaterials)}</h2>
       </AccordionSummary>

--- a/src/views/Profile/MaterialsView/PostsList.tsx
+++ b/src/views/Profile/MaterialsView/PostsList.tsx
@@ -73,7 +73,9 @@ export const PostsList: React.FC<IPostsListProps> = ({
                       component="h3"
                       className={classes.title}
                     >
-                      {post.title}
+                      {post.title.length > 50
+                        ? `${post.title.slice(0, 50)} ...`
+                        : post.title}
                     </Typography>
                   </Link>
                 </TableCell>

--- a/src/views/Profile/MaterialsView/styles/FilterSection.styles.ts
+++ b/src/views/Profile/MaterialsView/styles/FilterSection.styles.ts
@@ -1,0 +1,110 @@
+import { makeStyles } from '@material-ui/core';
+
+export const useStyles = makeStyles({
+  icon: {
+    borderRadius: 3,
+    width: '15px',
+    height: '15px',
+    backgroundColor: '#ffffff',
+    'input:disabled ~ &': {
+      boxShadow: 'none',
+      background: '#E5E5E5',
+      border: '3px solid white',
+    },
+    'input:hover ~ &': {
+      backgroundColor: '#ebf1f5',
+    },
+  },
+  checkedIcon: {
+    backgroundColor: '#4FDFFF',
+    borderRadius: 3,
+    display: 'block',
+    width: '15px',
+    height: '15px',
+    'input:hover ~ &': {
+      backgroundColor: '#106ba3',
+    },
+    '&:before': {
+      width: '14.38px',
+      height: '5.6px',
+      display: 'block',
+      content: "''",
+      position: 'relative',
+      borderBottom: '3px solid #000000',
+      borderLeft: '3px solid #000000',
+      transform: 'rotate(-45deg)',
+      left: '2px',
+      top: '2px',
+    },
+  },
+  formControlLabel: {
+    fontWeight: 700,
+    lineHeight: '18px',
+    height: '30px',
+    width: '160px',
+    margin: '0 0 9px -8px',
+  },
+
+  filtersWrapper: {
+    width: '280px',
+  },
+  filterTitle: {
+    fontFamily: 'Raleway',
+    fontStyle: 'normal',
+    width: '265px',
+    fontSize: '18px',
+    lineHeight: '18px',
+    fontWeight: 'bold',
+  },
+  divider: {
+    width: '280px',
+    height: '4px',
+    background: '#000000',
+    margin: '2px 0 20px 0',
+  },
+  formGroup: {
+    margin: '0 0 55px 0',
+    height: 'auto',
+    display: 'flex',
+    flexDirection: 'column',
+    flexWrap: 'nowrap',
+  },
+  allCheckedTrue: {
+    fontFamily: 'Raleway',
+    fontStyle: 'normal',
+    fontSize: '16px',
+    lineHeight: '18px',
+    fontWeight: 700,
+    color: '#000000',
+  },
+  allCheckedFalse: {
+    fontFamily: 'Raleway',
+    fontStyle: 'normal',
+    fontSize: '16px',
+    lineHeight: '18px',
+    fontWeight: 500,
+    color: '#000000',
+  },
+
+  labelChecked: {
+    height: '30px',
+    width: '160px',
+    margin: '0 0 10px -8px',
+    '& .MuiTypography-body1': {
+      fontFamily: 'Raleway',
+      fontWeight: 700,
+      lineHeight: '18px',
+    },
+  },
+
+  labelUnchecked: {
+    height: '30px',
+    width: '160px',
+    margin: '0 0 10px -8px',
+    '& .MuiTypography-body1': {
+      fontFamily: 'Raleway',
+      fontWeight: 500,
+      lineHeight: '18px',
+    },
+  },
+});

--- a/src/views/Profile/MaterialsView/styles/PostsList.styles.ts
+++ b/src/views/Profile/MaterialsView/styles/PostsList.styles.ts
@@ -5,7 +5,7 @@ export const useStyles = makeStyles(
     container: {
       display: 'flex',
       width: '100%',
-      padding: theme.spacing(6, 0, 0, 0),
+      padding: theme.spacing(5, 0, 0, 0),
     },
     item: {
       marginBottom: theme.spacing(2),
@@ -28,6 +28,7 @@ export const useStyles = makeStyles(
     title: {
       margin: theme.spacing(0),
       fontSize: '16px',
+      lineHeight: '18px',
       wordWrap: 'break-word',
       color: theme.palette.common.black,
     },


### PR DESCRIPTION
develop

## GitHub Board

**Issue link**

[#459 Add “Materials” tab at the “User Profile” with the possibility to see published and unpublished articles, review, edit, delete and filter them](https://github.com/ita-social-projects/dokazovi-fe/issues/459 )

**Story link**

[#82 Edit/delete unpublished materials](https://github.com/ita-social-projects/dokazovi-requirements/issues/82)
[#83 Review published materials](https://github.com/ita-social-projects/dokazovi-requirements/issues/83)


## Code reviewers
@sarhan-azizov 
@michalenr 
@NabokinAlexandr 


## Summary of change

- [x]  Fix bug Material tab at the user profile (item size, accordion arrow color)

