### PR TITLE
Fix items width acc to diff breakpoints at the Materials tab

### DIFF
--- a/src/views/Profile/MaterialsView/PostsList.tsx
+++ b/src/views/Profile/MaterialsView/PostsList.tsx
@@ -62,10 +62,7 @@ export const PostsList: React.FC<IPostsListProps> = ({
               ref={postIdxForScroll === idx ? postForScrollRef : null}
             >
               <Card className={classes.card}>
-                <TableCell
-                  className={classes.cell}
-                  style={{ minWidth: '480px' }}
-                >
+                <TableCell className={classes.cell} style={{ width: '360px' }}>
                   <Link to={`/posts/${post.id}`}>
                     <Typography
                       gutterBottom
@@ -82,7 +79,7 @@ export const PostsList: React.FC<IPostsListProps> = ({
                 <TableCell
                   className={classes.cell}
                   align="center"
-                  style={{ minWidth: '280px' }}
+                  style={{ minWidth: '180px' }}
                 >
                   <Typography variant="caption" color="textSecondary">
                     {status === PostStatus.DRAFT

--- a/src/views/Profile/MaterialsView/styles/PostsList.styles.ts
+++ b/src/views/Profile/MaterialsView/styles/PostsList.styles.ts
@@ -4,6 +4,7 @@ export const useStyles = makeStyles(
   (theme: Theme) => ({
     container: {
       display: 'flex',
+      justifyContent: 'center',
       width: '100%',
       padding: theme.spacing(5, 0, 0, 0),
     },
@@ -13,7 +14,6 @@ export const useStyles = makeStyles(
     card: {
       position: 'relative',
       display: 'flex',
-      minWidth: '835px',
       alignItems: 'center',
       border: 'none',
       '&:hover': {
@@ -22,8 +22,12 @@ export const useStyles = makeStyles(
       },
     },
     cell: {
+      minWidth: '500px',
       border: 'none',
       padding: theme.spacing(0, 2, 0, 2),
+      [theme.breakpoints.down('md')]: {
+        minWidth: '360px',
+      },
     },
     title: {
       margin: theme.spacing(0),


### PR DESCRIPTION
develop

## GitHub Board

**Issue link**

[#459 Add “Materials” tab at the “User Profile” with the possibility to see published and unpublished articles, review, edit, delete and filter them](https://github.com/ita-social-projects/dokazovi-fe/issues/459 )

**Story link**

[#82 Edit/delete unpublished materials](https://github.com/ita-social-projects/dokazovi-requirements/issues/82)
[#83 Review published materials](https://github.com/ita-social-projects/dokazovi-requirements/issues/83)


## Code reviewers
@sarhan-azizov 
@michalenr 
@NabokinAlexandr 


## Summary of change

- [x]  Fix items width acc to diff breakpoints at the Materials tab

