### PR TITLE
Bugfix Wrong scroll position after page refresh or query string change

### DIFF
--- a/src/components/ScrollToTop/ScrollToTop.tsx
+++ b/src/components/ScrollToTop/ScrollToTop.tsx
@@ -2,11 +2,14 @@ import { useEffect } from 'react';
 import { useLocation } from 'react-router-dom';
 
 export default function ScrollToTop() {
-  const { pathname } = useLocation();
+  const { pathname, search } = useLocation();
+  useEffect(() => {
+    window.history.scrollRestoration = 'manual';
+  }, []);
 
   useEffect(() => {
     window.scrollTo(0, 0);
-  }, [pathname]);
+  }, [pathname, search]);
 
   return null;
 }


### PR DESCRIPTION
develop

## GitHub Board

## Code reviewers

@sarhan-azizov
@michalenr
@NabokinAlexandr

## Summary of issue

The page is displayed in the same scroll position after refreshing the page or changing query string