### PR TITLE
Fix responsiveness of the Main View page

### DIFF
--- a/src/features/newest/newestPostsList/NewestPostsList.styles.ts
+++ b/src/features/newest/newestPostsList/NewestPostsList.styles.ts
@@ -32,11 +32,13 @@ export const useStyles = makeStyles(
         },
       },
       grid: {
-        gap: '15px',
         minHeight: '315px',
         justifyContent: 'space-between',
-        [theme.breakpoints.down('sm')]: {
-          justifyContent: 'center',
+        flexWrap: 'nowrap',
+        overflow: 'auto',
+        [theme.breakpoints.down('md')]: {
+          justifyContent: 'flex-start',
+          gap: '15px',
         },
       },
     }),

--- a/src/features/newest/newestPostsList/NewestPostsList.tsx
+++ b/src/features/newest/newestPostsList/NewestPostsList.tsx
@@ -27,14 +27,11 @@ export const NewestPostsList: React.FC<INewestPostsListProps> = ({
   const classes = useStyles();
 
   const displayPostPreviewCards = () => {
-    return (
-      postsList &&
-      postsList.map((post) => (
-        <div key={post.id}>
-          <PostPreviewCard key={post.id} post={post} />
-        </div>
-      ))
-    );
+    return postsList?.map((post) => (
+      <div key={post.id}>
+        <PostPreviewCard key={post.id} post={post} />
+      </div>
+    ));
   };
 
   const displaySkeletons = () =>

--- a/src/old/lib/components/Pages/Page.tsx
+++ b/src/old/lib/components/Pages/Page.tsx
@@ -10,10 +10,8 @@ const Page: React.FC<IPageProps> = (props) => {
   const classes = useStyles();
 
   return (
-    <Container className={classes.container} disableGutters>
-      <div className={classes.page}>
-        <props.component />
-      </div>
+    <Container className={classes.page} disableGutters>
+      <props.component />
     </Container>
   );
 };

--- a/src/old/lib/styles/Page.styles.ts
+++ b/src/old/lib/styles/Page.styles.ts
@@ -2,16 +2,9 @@ import { makeStyles, Theme } from '@material-ui/core';
 
 export const useStyles = makeStyles(
   (theme: Theme) => ({
-    container: {
-      display: 'flex',
-      flexDirection: 'column',
-      flexGrow: 1,
-    },
     page: {
-      margin: theme.spacing(10, 0),
-      display: 'flex',
-      flexDirection: 'column',
-      flexGrow: 1,
+      margin: theme.spacing(10, 'auto'),
+      padding: theme.spacing(0, 5),
     },
   }),
   { name: 'Page' },

--- a/src/old/lib/theme/theme.ts
+++ b/src/old/lib/theme/theme.ts
@@ -11,7 +11,7 @@ export const MAIN_THEME = createMuiTheme({
       xs: 0,
       sm: 600,
       md: 960,
-      lg: 1305,
+      lg: 1355,
       xl: 1920,
     },
   },


### PR DESCRIPTION
## Summary of issue

Fixed problems with responsive design on laptop screens.

Left and right gap was added. 

Materials cards in a grid list now have horizontal scroll on small screens (~11 inches laptops and iPads). 13 inches displays fit 4 items
