### PR TITLE
Change empty output message position

### DIFF
--- a/src/components/Notifications/Notification.tsx
+++ b/src/components/Notifications/Notification.tsx
@@ -14,7 +14,7 @@ export const Notification: React.FC<INotificationProps> = ({ message }) => {
         userSelect: 'none',
         width: '400px',
         height: '200px',
-        margin: '100px auto 0 auto',
+        margin: '100px auto 0',
       }}
       container
       direction="column"

--- a/src/components/Notifications/Notification.tsx
+++ b/src/components/Notifications/Notification.tsx
@@ -10,13 +10,11 @@ export const Notification: React.FC<INotificationProps> = ({ message }) => {
   return (
     <Grid
       style={{
-        position: 'sticky',
-        top: '45vh',
         fontSize: '24px',
         userSelect: 'none',
         width: '400px',
-        height: '160px',
-        margin: '30px auto',
+        height: '200px',
+        margin: '100px auto 0 auto',
       }}
       container
       direction="column"

--- a/src/old/modules/experts/components/ExpertMaterialsContainer.tsx
+++ b/src/old/modules/experts/components/ExpertMaterialsContainer.tsx
@@ -379,7 +379,7 @@ const ExpertMaterialsContainer: React.FC<IExpertMaterialsContainerProps> = ({
           userSelect: 'none',
           width: '400px',
           height: '200px',
-          margin: '100px auto 0 auto',
+          margin: '100px auto 0',
         }}
         container
         direction="column"

--- a/src/old/modules/experts/components/ExpertMaterialsContainer.tsx
+++ b/src/old/modules/experts/components/ExpertMaterialsContainer.tsx
@@ -375,13 +375,11 @@ const ExpertMaterialsContainer: React.FC<IExpertMaterialsContainerProps> = ({
     materialsData = (
       <Grid
         style={{
-          position: 'sticky',
-          top: '45vh',
           fontSize: '24px',
           userSelect: 'none',
           width: '400px',
           height: '200px',
-          margin: '0 auto',
+          margin: '100px auto 0 auto',
         }}
         container
         direction="column"


### PR DESCRIPTION
develop

## GitHub Board

**Issue link**

[Fix message with fixed position when output is empty #518 ]( https://github.com/ita-social-projects/dokazovi-fe/issues/518)


## Summary of issue

Position was set to sticky so message was moving when user was scrolling page.


## Summary of change

Removed sticky position (changed to default static) and added margin at the top.
