### PR TITLE
Bugfix ReactQuill Editor scrolls to top when pasting large content

### DIFF
--- a/src/components/Editor/GeneralEditor.tsx
+++ b/src/components/Editor/GeneralEditor.tsx
@@ -45,6 +45,7 @@ const Editor: React.FC<IQuillEditorProps> = (props) => {
         modules={modules}
         formats={formats}
         ref={editorRef}
+        scrollingContainer="html"
       />
     </div>
   );

--- a/src/components/Editor/generalEditor.styles.css
+++ b/src/components/Editor/generalEditor.styles.css
@@ -110,3 +110,7 @@ blockquote {
   text-decoration: underline;
   color: #0000ff;
 }
+
+.ql-clipboard {
+  position: fixed !important;
+}


### PR DESCRIPTION
develop

## GitHub Board

## Code reviewers

@sarhan-azizov
@michalenr
@NabokinAlexandr

## Summary of issue

After pasting in content, ReactQuill does resume the original scroll position after the screen flickers