### PR TITLE
Fix/remove carousel limit

### DIFF
--- a/src/components/Posts/Cards/ImportantPostPreviewCard/ImportantPostPreviewCard.styles.ts
+++ b/src/components/Posts/Cards/ImportantPostPreviewCard/ImportantPostPreviewCard.styles.ts
@@ -37,6 +37,7 @@ const sizeModes = {
   large: {
     root: {
       height: 455,
+      width: 1200,
       padding: [14, 5, 11, 11],
     },
     title: {

--- a/src/old/lib/components/Users/AdminPage/components/ImportantView.tsx
+++ b/src/old/lib/components/Users/AdminPage/components/ImportantView.tsx
@@ -128,7 +128,7 @@ const ImportantView: React.FC = () => {
           color="primary"
           variant="contained"
           size="large"
-          disabled={mappedPosts.length < 2}
+          disabled={mappedPosts.length < 1}
           onClick={() => setPreviewStatus(true)}
         >
           Переглянути
@@ -138,7 +138,7 @@ const ImportantView: React.FC = () => {
           color="primary"
           variant="contained"
           size="large"
-          disabled={mappedPosts.length < 2}
+          disabled={mappedPosts.length < 1}
           onClick={publishImportantPosts}
         >
           Публікувати

--- a/src/old/modules/main/styles/ImportantContainer.styles.ts
+++ b/src/old/modules/main/styles/ImportantContainer.styles.ts
@@ -4,16 +4,14 @@ export const useStyles = makeStyles(
   {
     container: {
       minHeight: 455,
-      display: 'flex',
-      flexDirection: 'column',
-      justifyContent: 'center',
+      width: 1200,
     },
-    containerMobile:{
+    containerMobile: {
       minHeight: 585,
       display: 'flex',
       flexDirection: 'column',
       justifyContent: 'center',
-    }
+    },
   },
   { name: 'ImportantContainer' },
 );


### PR DESCRIPTION
develop

## Issue
[The system does not allow edit if there is one material in carrousel](https://github.com/ita-social-projects/dokazovi-requirements/issues/216)

## Summary of issue

Admin wasn't able to add only one image to carousel slider.


## Summary of change

Changed limit to 1 image at slider. Adjusted styles
