### PR TITLE
Fix clickable link margin

### DIFF
--- a/src/features/newest/newestPostsList/NewestPostsList.styles.ts
+++ b/src/features/newest/newestPostsList/NewestPostsList.styles.ts
@@ -3,11 +3,14 @@ import { createStyles, makeStyles, Theme } from '@material-ui/core';
 export const useStyles = makeStyles(
   (theme: Theme) =>
     createStyles({
+      container: {
+        marginTop: theme.spacing(10),
+      },
       header: {
         display: 'flex',
         justifyContent: 'space-between',
         gap: '15px',
-        margin: theme.spacing(10, 0, 4, 0),
+        marginBottom: theme.spacing(4),
         cursor: 'pointer',
       },
       postsType: {

--- a/src/features/newest/newestPostsList/NewestPostsList.tsx
+++ b/src/features/newest/newestPostsList/NewestPostsList.tsx
@@ -50,7 +50,7 @@ export const NewestPostsList: React.FC<INewestPostsListProps> = ({
     ));
 
   return (
-    <>
+    <div className={classes.container}>
       <Link to={postsListPath}>
         <div className={classes.header}>
           <Typography
@@ -74,6 +74,6 @@ export const NewestPostsList: React.FC<INewestPostsListProps> = ({
           ? displaySkeletons()
           : displayPostPreviewCards()}
       </Grid>
-    </>
+    </div>
   );
 };


### PR DESCRIPTION
develop

## GitHub Board

**Issue link**

[Clickable fields](https://github.com/ita-social-projects/dokazovi-requirements/issues/251)

## Summary of issue

Fields above actual link was clickable

## Summary of change

Adjusted styles so area above isn't clickable anymore 