### PR TITLE
bugfix-259: fix label in tab article

### DIFF
--- a/src/views/postCreation/ArticleCreation.tsx
+++ b/src/views/postCreation/ArticleCreation.tsx
@@ -21,7 +21,7 @@ const ArticleCreation: React.FC = () => {
       contentInputLabel={`${t(langTokens.editor.articleText)}:`}
       postType={{
         type: PostTypeEnum.ARTICLE,
-        name: t(langTokens.common.post),
+        name: t(langTokens.common.article),
       }}
     />
   );


### PR DESCRIPTION
develop

## GitHub Board

**https://github.com/ita-social-projects/dokazovi-requirements/issues/259**

[Incorrect label in tab 'Стаття' #259 ]( )

