### PR TITLE
Fix "load more" button on mobile

### DIFF
--- a/src/old/lib/components/LoadMoreButton/LoadMoreButton.styles.ts
+++ b/src/old/lib/components/LoadMoreButton/LoadMoreButton.styles.ts
@@ -17,6 +17,9 @@ export const useStyles = makeStyles(
           height: '1px',
           margin: 'auto',
           backgroundColor: theme.palette.common.black,
+          [theme.breakpoints.down('xs')]: {
+            display: 'none',
+          },
         },
         [theme.breakpoints.down('xs')]: {
           margin: theme.spacing(0, 3, 14),

--- a/src/old/lib/components/LoadMoreButton/LoadMoreButton.tsx
+++ b/src/old/lib/components/LoadMoreButton/LoadMoreButton.tsx
@@ -1,7 +1,8 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import { Button, Box } from '@material-ui/core';
 import RefreshIcon from '@material-ui/icons/Refresh';
 import { useTranslation } from 'react-i18next';
+import { ScreenContext } from 'old/provider/MobileProvider/ScreenContext';
 import { LoadingStatusEnum, LoadMoreButtonTextType } from '../../types';
 import {
   LOAD_POSTS_LIMIT,
@@ -46,6 +47,7 @@ export const LoadMoreButton: React.FC<ILoadMoreButtonProps> = ({
   const classes = useStyles();
 
   const { t } = useTranslation();
+  const { mobile } = useContext(ScreenContext);
 
   const getButtonText = (
     count: number,
@@ -86,7 +88,8 @@ export const LoadMoreButton: React.FC<ILoadMoreButtonProps> = ({
               loading === LoadingStatusEnum.pending ? classes.spinning : ''
             }
           />
-          {t(langTokens.common.showMore)} {elementsInNextPage} {buttonText}
+          {t(langTokens.common.showMore)} {elementsInNextPage}{' '}
+          {!mobile && buttonText}
         </Button>
       </Box>
     );


### PR DESCRIPTION
develop

## Summary of issue

Load more button (on mobile) wasn't matching the [mockups](https://www.figma.com/file/WQLQeDdGX55TRdUcNp70ni/Dokazovi-Mob-3?node-id=0%3A1).

## Summary of change

Adjusted styles and removed excess text of the button
