### PR TITLE
Fix selected filters adaptive

### DIFF
--- a/src/old/modules/experts/styles/ExpertsView.styles.ts
+++ b/src/old/modules/experts/styles/ExpertsView.styles.ts
@@ -4,7 +4,7 @@ export const useStyles = makeStyles(
   (theme: Theme) => ({
     container: {
       display: 'flex',
-      flexWrap: 'nowrap',
+      flexWrap: 'wrap',
       margin: '7px 0px 15px 0px',
       justifyContent: 'flex-start',
       alignItems: 'center',

--- a/src/old/modules/materials/styles/MaterialsView.styles.ts
+++ b/src/old/modules/materials/styles/MaterialsView.styles.ts
@@ -4,7 +4,7 @@ export const useStyles = makeStyles(
   (theme) => ({
     container: {
       display: 'flex',
-      flexWrap: 'nowrap',
+      flexWrap: 'wrap',
       margin: '7px 0px 15px 0px',
       justifyContent: 'flex-start',
       alignItems: 'center',


### PR DESCRIPTION
develop

## GitHub Board

**Issue link**

[Selected filters don't adapt to resizing page](https://github.com/ita-social-projects/dokazovi-requirements/issues/308 )

## Summary of issue

After resizing the page, filters aren't adapting to page size

## Summary of change

Added flex wrap property, so selected filters that don't fit the page width will be carried over to next row
