### PR TITLE
Bugfix-298: Incorrect checkboxes work in filter 'за джерелом'

### DIFF
--- a/src/old/modules/materials/components/MaterialsView.tsx
+++ b/src/old/modules/materials/components/MaterialsView.tsx
@@ -265,7 +265,10 @@ const MaterialsView: React.FC = () => {
     query.get(QueryTypeEnum.DIRECTIONS),
   ]);
 
-  const selectedOriginsString = query.get(QueryTypeEnum.ORIGINS)?.split(',');
+  const selectedOriginsString =
+    query.get(QueryTypeEnum.ORIGINS) === '0'
+      ? stringOfOrigins().split(' ')
+      : query.get(QueryTypeEnum.ORIGINS)?.split(',');
 
   let selectedOrigins:
     | IOrigin[]


### PR DESCRIPTION
develop

## GitHub Board

**Issue link**

[Incorrect checkboxes work in filter 'за джерелом' in tab 'Матеріали'](https://github.com/ita-social-projects/dokazovi-requirements/issues/298)

**Summary of issue**

- After checking checkboxes 'Думки експертів','Переклади','Медитека' in filter 'за джерелом' should be checked 'Всі джерела' 'Думки експертів','Переклади','Медитека'/

