### PR TITLE
#408 Add UpButton on the 'Матеріали' page

### DIFF
--- a/src/old/lib/components/UpButton/UpButton.styles.ts
+++ b/src/old/lib/components/UpButton/UpButton.styles.ts
@@ -1,0 +1,26 @@
+import { makeStyles, createStyles } from '@material-ui/core';
+
+export const useStyles = makeStyles(
+  (theme) =>
+    createStyles({
+      button: {
+        position: 'fixed',
+        bottom: 20,
+        left: 25,
+        padding: '12px 10px',
+        backgroundColor: '#000000',
+        opacity: '0.4',
+        color: 'white',
+        borderRadius: '40px',
+        zIndex: 1200,
+        '&.MuiButton-root:focus': {
+          backgroundColor: '#000000',
+          opacity: '0.4',
+        },
+      },
+      upIcon: {
+        fontSize: 40,
+      },
+    }),
+  { name: 'UpButton' },
+);

--- a/src/old/lib/components/UpButton/UpButton.tsx
+++ b/src/old/lib/components/UpButton/UpButton.tsx
@@ -1,0 +1,30 @@
+import React, { FC } from 'react';
+import { Button } from '@material-ui/core';
+import ArrowUpwardIcon from '@material-ui/icons/ArrowUpward';
+import { useStyles } from './UpButton.styles';
+
+const UpButton: FC = () => {
+  const classes = useStyles();
+
+  const handleScrollUp = () => {
+    window.scrollTo({
+      top: 0,
+      left: 0,
+      behavior: 'smooth',
+    });
+  };
+
+  return (
+    <Button
+      className={`
+        ${classes.button} 
+        
+      `}
+      onClick={handleScrollUp}
+    >
+      <ArrowUpwardIcon className={classes.upIcon} />
+    </Button>
+  );
+};
+
+export default UpButton;

--- a/src/old/modules/materials/components/MaterialsViewMobile.tsx
+++ b/src/old/modules/materials/components/MaterialsViewMobile.tsx
@@ -5,6 +5,7 @@ import { PostsList } from 'old/lib/components/Posts/PostsList';
 import FiltersMenu from 'components/FiltersMenuMobile/FiltersMenu';
 import FiltersButton from 'old/lib/components/FiltersButton/FiltersButton';
 import { IPost, LoadingStatusType, LoadingStatusEnum } from 'old/lib/types';
+import UpButton from 'old/lib/components/UpButton/UpButton';
 import { useStyles } from '../styles/MaterialsViewMobile.styles';
 
 interface IMaterialsViewMobileProps {
@@ -55,6 +56,7 @@ const MaterialsViewMobile: FC<IMaterialsViewMobileProps> = ({
           </>
         )}
       </Grid>
+      <UpButton />
       <FiltersButton
         filtersMenuOpen={filtersMenuOpen}
         setFiltersMenuOpen={setFiltersMenuOpen}

--- a/src/views/postUpdation/__tests__/__snapshots__/TextPostUpdation.test.jsx.snap
+++ b/src/views/postUpdation/__tests__/__snapshots__/TextPostUpdation.test.jsx.snap
@@ -63,7 +63,7 @@ exports[`TextPostUpdation tests should render component 1`] = `
         </div>
       </div>
       <div
-        class="MuiCollapse-container MuiCollapse-hidden"
+        class="MuiCollapse-root MuiCollapse-hidden"
         style="min-height: 0px;"
       >
         <div
@@ -213,7 +213,7 @@ exports[`TextPostUpdation tests should render component 1`] = `
         </div>
       </div>
       <div
-        class="MuiCollapse-container MuiCollapse-hidden"
+        class="MuiCollapse-root MuiCollapse-hidden"
         style="min-height: 0px;"
       >
         <div


### PR DESCRIPTION
### Type of Pull Request *
- [ ] CHANGE (fix or feature that would cause existing functionality to not work as expected)
- [ ] FEATURE (non-breaking change which adds functionality)
- [x] BUGFIX (non-breaking change which fixes an issue)
- [ ] ENHANCEMENT  (non-breaking change which improves existing functionality)
- [ ] NONE (if none of the other choices apply. For example, tooling, build system, CI, docs, etc.)

### Related links
 
**Issue link**
[#408 [Bug Report] [Mobile] The 'Up' button does not exist on the 'Матеріали' page](https://github.com/ita-social-projects/dokazovi-requirements/issues/408 )
 
**Story link**
[#209 Materials Page(mobile).](https://github.com/ita-social-projects/dokazovi-requirements/issues/209 )
 
### Description *
The 'Up' button does not exist on the 'Матеріали' page on mobile version.
 
###Summary of issue
The 'Up' button does not exist on the 'Матеріали' page on mobile version.
 
###Summary of change
Add the 'Up' button on the 'Матеріали' page on mobile version.