### PR TITLE
Bugfix #459 Hamburger menu links wrong highlighting

### DIFF
--- a/src/components/BurgerMenu/BurgerMenu.tsx
+++ b/src/components/BurgerMenu/BurgerMenu.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import {
   Drawer,
   Hidden,
@@ -8,7 +8,7 @@ import {
 } from '@material-ui/core';
 import MenuIcon from '@material-ui/icons/Menu';
 import { useTranslation } from 'react-i18next';
-import { NavLink } from 'react-router-dom';
+import { NavLink, Link } from 'react-router-dom';
 import { langTokens } from '../../locales/localizationInit';
 import { IHeaderProps } from '../Header/types';
 import { useStyles } from './BurgerMenuSyle';
@@ -31,6 +31,8 @@ export const BurgerMenu: React.FC<IBurgerMenuProps> = ({
   const handleDrawerToggle = () => {
     setMobileMenuOpen(!mobileMenuOpen);
   };
+
+  const [activeId, setActiveId] = useState<number>();
 
   return (
     <div>
@@ -73,17 +75,24 @@ export const BurgerMenu: React.FC<IBurgerMenuProps> = ({
                 </NavLink>
               ))}
               {navElements.map((item) => (
-                <NavLink
-                  className={classes.link}
-                  onClick={handleDrawerToggle}
+                <Link
+                  className={
+                    activeId === item.id
+                      ? `${classes.link} active`
+                      : classes.link
+                  }
+                  onClick={() => setActiveId(item.id)}
                   to={item.url}
                   key={item.id}
-                  exact
                 >
-                  <Typography className={classes.footerLinks} component="span">
+                  <Typography
+                    className={classes.footerLinks}
+                    component="h6"
+                    variant="h2"
+                  >
                     {item.label}
                   </Typography>
-                </NavLink>
+                </Link>
               ))}
             </List>
           </div>

--- a/src/components/BurgerMenu/BurgerMenuSyle.ts
+++ b/src/components/BurgerMenu/BurgerMenuSyle.ts
@@ -18,11 +18,11 @@ export const useStyles = makeStyles((theme) => ({
     color: 'white',
     height: '100%',
     border: 'none',
-    width: `207px`,
+    width: `200px`,
     paddingLeft: theme.spacing(5),
   },
   link: {
-    display:'block',
+    display: 'block',
     marginTop: theme.spacing(8),
     color: theme.palette.primary.main,
     fontWeight: 600,
@@ -39,7 +39,7 @@ export const useStyles = makeStyles((theme) => ({
     fontSize: 16,
     lineHeight: '18px',
   },
-  root:{
-    backgroundColor:theme.palette.common.black,
+  root: {
+    backgroundColor: theme.palette.common.black,
   },
 }));


### PR DESCRIPTION
Pull Request Template
 

### Type of Pull Request *
- [ ] CHANGE (fix or feature that would cause existing functionality to not work as expected)
- [ ] FEATURE (non-breaking change which adds functionality)
- [x] BUGFIX (non-breaking change which fixes an issue)
- [ ] ENHANCEMENT  (non-breaking change which improves existing functionality)
- [ ] NONE (if none of the other choices apply. For example, tooling, build system, CI, docs, etc.)

### Related links
 
**Issue link**
[#459 [Bug Report] [Mobile] Hamburger menu: Navigation Menu with three highlighted names of the items instead one is appeared after tap Hamburger menu icon](https://github.com/ita-social-projects/dokazovi-requirements/issues/459)
 
**Story link**
[#204 Hamburger Menu](https://github.com/ita-social-projects/dokazovi-requirements/issues/204)
 
### Description *
Wrong highlighting of the links 'Про платформу', 'Правила використання', 'Контакти' after click
 
###Summary of issue
All links 'Про платформу', 'Правила використання', 'Контакти' are highlighed in bold letters after clicking on the particular one instead of highlighting an active link
 
###Summary of change
Implemented logic of adding an active class for the active link of the hamburger menu after clicking
 
 
 
"*" - mandatory field
