### PR TITLE
Issue 468 Material card is redirected to the new screen

### DIFF
--- a/src/components/Posts/Cards/ExpertOpinionPostPreviewCard/ExpertOpinionPostPreviewCard.tsx
+++ b/src/components/Posts/Cards/ExpertOpinionPostPreviewCard/ExpertOpinionPostPreviewCard.tsx
@@ -123,9 +123,17 @@ export const ExpertOpinionPostPreviewCard: React.FC<IPostPreviewCardProps> = ({
       {shouldNotUseLink ? (
         expertBody
       ) : (
-        <Link to={expertLink}>{expertBody}</Link>
+        <Link to={expertLink} target="_blank">
+          {expertBody}
+        </Link>
       )}
-      {shouldNotUseLink ? postBody : <Link to={postLink}>{postBody}</Link>}
+      {shouldNotUseLink ? (
+        postBody
+      ) : (
+        <Link to={postLink} target="_blank">
+          {postBody}
+        </Link>
+      )}
     </Card>
   );
 };

--- a/src/components/Posts/Cards/MediaPostPreviewCard/MediaPostPreviewCard.tsx
+++ b/src/components/Posts/Cards/MediaPostPreviewCard/MediaPostPreviewCard.tsx
@@ -69,7 +69,13 @@ export const MediaPostPreviewCard: React.FC<IPostPreviewCardProps> = ({
 
   return (
     <Card className={classes.root}>
-      {shouldNotUseLink ? card : <Link to={postLink}>{card}</Link>}
+      {shouldNotUseLink ? (
+        card
+      ) : (
+        <Link to={postLink} target="_blank">
+          {card}
+        </Link>
+      )}
     </Card>
   );
 };

--- a/src/components/Posts/Cards/TranslationPostPreviewCard/TranslationPostPreviewCard.tsx
+++ b/src/components/Posts/Cards/TranslationPostPreviewCard/TranslationPostPreviewCard.tsx
@@ -121,7 +121,13 @@ export const TranslationPostPreviewCard: React.FC<IPostPreviewCardProps> = ({
             {cardBody}
           </Typography>
         )}
-        {shouldNotUseLink ? cardText : <Link to={postLink}>{cardText}</Link>}
+        {shouldNotUseLink ? (
+          cardText
+        ) : (
+          <Link to={postLink} target="_blank">
+            {cardText}
+          </Link>
+        )}
       </Box>
     </Card>
   );

--- a/src/components/Posts/Cards/VideoPostPreviewCard/VideoPostPreviewCard.tsx
+++ b/src/components/Posts/Cards/VideoPostPreviewCard/VideoPostPreviewCard.tsx
@@ -65,7 +65,13 @@ export const VideoPostPreviewCard: React.FC<IPostPreviewCardProps> = ({
   );
   return (
     <Card className={classes.root}>
-      {shouldNotUseLink ? card : <Link to={postLink}>{card}</Link>}
+      {shouldNotUseLink ? (
+        card
+      ) : (
+        <Link to={postLink} target="_blank">
+          {card}
+        </Link>
+      )}
     </Card>
   );
 };


### PR DESCRIPTION
### Type of Pull Request *
- [ ] CHANGE (fix or feature that would cause existing functionality to not work as expected)
- [ ] FEATURE (non-breaking change which adds functionality)
- [x] BUGFIX (non-breaking change which fixes an issue)
- [ ] ENHANCEMENT  (non-breaking change which improves existing functionality)
- [ ] NONE (if none of the other choices apply. For example, tooling, build system, CI, docs, etc.)

### Related links
 
**Issue link**
[#468 [Mobile] Main page: Material card is not redirected to the new screen]( https://github.com/ita-social-projects/dokazovi-requirements/issues/468 )
 
**Story link**
[#303 Material's Full View on a separate page(mobile)]( https://github.com/ita-social-projects/dokazovi-requirements/issues/303 )
 
### Description *
Material card is not redirected to the new screen.

### Summary of issue
Material card is not redirected to the new screen. Also, this bug affected the 'Автори' page, 'Матеріали' page.
 
### Summary of change
Implement redirection of Material card from the Main page to the new page. Now, Material card from the 'Автори' page, 'Матеріали' page is redirected to the new screen, too.
 
