### PR TITLE
Issue 442 Material screen: 'Вибрано' inscription is not displayed in the upper part of 'Filter' menu

### DIFF
--- a/src/components/FiltersMenuMobile/FiltersMenu.styles.ts
+++ b/src/components/FiltersMenuMobile/FiltersMenu.styles.ts
@@ -10,6 +10,9 @@ export const useStyles = makeStyles(
     container: {
       justifyContent: 'space-between',
     },
+    containerSelected: {
+      marginTop: '85px',
+    },
     headerSelected: {
       color: '#FF5C00',
       fontFamily: 'Raleway',
@@ -21,7 +24,8 @@ export const useStyles = makeStyles(
       fontFamily: 'Literata',
       fontSize: '14px',
       fontWeight: 400,
-      fontStyleL: 'italic',
+      fontStyle: 'italic',
+      paddingLeft: '15px',
     },
     selectedTypesContainer: {
       alignItems: 'center',

--- a/src/components/FiltersMenuMobile/FiltersMenu.tsx
+++ b/src/components/FiltersMenuMobile/FiltersMenu.tsx
@@ -39,7 +39,7 @@ const FiltersMenu: FC<IFiltersMenuProps> = ({
       }}
     >
       <Grid container>
-        <Grid container direction="row" className={classes.container}>
+        <Grid container direction="row" className={classes.containerSelected}>
           <Typography className={classes.headerSelected}>
             {t(langTokens.common.selected)}:
           </Typography>


### PR DESCRIPTION
### Type of Pull Request *
- [ ] CHANGE (fix or feature that would cause existing functionality to not work as expected)
- [ ] FEATURE (non-breaking change which adds functionality)
- [x] BUGFIX (non-breaking change which fixes an issue)
- [ ] ENHANCEMENT  (non-breaking change which improves existing functionality)
- [ ] NONE (if none of the other choices apply. For example, tooling, build system, CI, docs, etc.)

### Related links
 
**Issue link**
[#442 [Bug Report] [Mobile] Material screen: 'Вибрано' inscription is not displayed in the upper part of 'Filter' menu.](https://github.com/ita-social-projects/dokazovi-requirements/issues/442)
 
**Story link**
[#217 Materials page's filters(mobile)]( https://github.com/ita-social-projects/dokazovi-requirements/issues/217)
 
### Description *
Material screen: 'Вибрано' inscription was not displayed in the upper part of 'Filter' menu.
 
###Summary of issue
[Mobile] Material screen: 'Вибрано' inscription is not displayed in the upper part of 'Filter' menu.
 
###Summary of change
Change visibility of title 'Вибрано' in the upper part of 'Filter' menu.
 