### PR TITLE
The counter is not shown at top section of opened material card

### DIFF
--- a/src/components/Posts/PostInfo/PostInfo.tsx
+++ b/src/components/Posts/PostInfo/PostInfo.tsx
@@ -68,20 +68,18 @@ export default function PostInfo({ info }: IPostInfo): JSX.Element {
           </li>
         )}
         <li className={classes.createdAt}>{publishedAt}</li>
-        {!mobile && (
-          <>
-            <li className={classes.icon} data-testid="icon">
-              <VisibilityIcon fontSize="small" />
-            </li>
-            <li className={classes.counter} data-testid="counter">
-              {uniqueViewsCounter === undefined ? (
-                <Skeleton width={40} height={20} data-testid="skeleton" />
-              ) : (
-                uniqueViewsCounter
-              )}
-            </li>
-          </>
-        )}
+        <>
+          <li className={classes.icon} data-testid="icon">
+            <VisibilityIcon fontSize="small" />
+          </li>
+          <li className={classes.counter} data-testid="counter">
+            {uniqueViewsCounter === undefined ? (
+              <Skeleton width={40} height={20} data-testid="skeleton" />
+            ) : (
+              uniqueViewsCounter
+            )}
+          </li>
+        </>
       </ul>
     </div>
   );

--- a/src/components/Posts/PostInfo/__tests__/PostInfo.test.tsx
+++ b/src/components/Posts/PostInfo/__tests__/PostInfo.test.tsx
@@ -108,15 +108,15 @@ describe('PostInfo tests', () => {
     expect(history.location.search).toBe('?types=1');
   });
 
-  it('should mobile be without Views Counter', () => {
+  it('should mobile be with Views Counter', () => {
     const { asFragment } = render(
       <ScreenContext.Provider value={{ mobile: true, tablet: null }}>
         <PostInfo info={mocks.info} />
       </ScreenContext.Provider>,
     );
 
-    expect(screen.queryByTestId('icon')).not.toBeInTheDocument();
-    expect(screen.queryByTestId('counter')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('icon')).toBeInTheDocument();
+    expect(screen.queryByTestId('counter')).toBeInTheDocument();
 
     expect(asFragment()).toMatchSnapshot();
   });


### PR DESCRIPTION
Pull Request Template
 

### Type of Pull Request *
- [ ] CHANGE (fix or feature that would cause existing functionality to not work as expected)
- [ ] FEATURE (non-breaking change which adds functionality)
- [x] BUGFIX (non-breaking change which fixes an issue)
- [ ] ENHANCEMENT  (non-breaking change which improves existing functionality)
- [ ] NONE (if none of the other choices apply. For example, tooling, build system, CI, docs, etc.)

### Related links
 
**Issue link**
['Матеріали' page: The counter is not shown at top section of opened material card](https://github.com/ita-social-projects/dokazovi-requirements/issues/464)
 
**Story link**
[#11 Story]( https://github.com/ita-social-projects/dokazovi-requirements/issues/302)
 
### Description *
Now both counters for mobile and desktop version are working
