### PR TITLE
Bugfix 465 mobile filter items disabling

### DIFF
--- a/src/old/lib/components/Filters/CheckboxLeftsideFilterForm.tsx
+++ b/src/old/lib/components/Filters/CheckboxLeftsideFilterForm.tsx
@@ -183,9 +183,9 @@ export const CheckboxLeftsideFilterForm: React.FC<ICheckboxLeftsideFilterFormPro
     }
 
     if (filterType === QueryTypeEnum.ORIGINS) {
-      const origin = allOrigins.map((origin) => origin.id);
+      const originItem = allOrigins.map((origin) => origin.id);
       const filterNameValue = +filterName!;
-      result = origin?.includes(filterNameValue);
+      result = originItem?.includes(filterNameValue);
     }
 
     return result;

--- a/src/old/lib/components/Filters/CheckboxLeftsideFilterForm.tsx
+++ b/src/old/lib/components/Filters/CheckboxLeftsideFilterForm.tsx
@@ -165,12 +165,27 @@ export const CheckboxLeftsideFilterForm: React.FC<ICheckboxLeftsideFilterFormPro
     onFormChange(checkedFilters);
   };
 
-  const getUsersPresentProperty = (filterName: string | undefined) => {
+  const getUsersPresentProperty = (filterName: string | number | undefined) => {
     const allRegions = store.getState().properties.regions;
+    const allDirections = store.getState().properties.directions;
+    const allOrigins = store.getState().properties.origins;
+
     let result: boolean | undefined = false;
+
     if (filterType === QueryTypeEnum.REGIONS) {
       const region = allRegions.find((reg) => reg.name === filterName);
       result = region?.usersPresent;
+    }
+
+    if (filterType === QueryTypeEnum.DIRECTIONS) {
+      const direction = allDirections.find((dir) => dir.name === filterName);
+      result = direction?.hasPosts;
+    }
+
+    if (filterType === QueryTypeEnum.ORIGINS) {
+      const origin = allOrigins.map((origin) => origin.id);
+      const filterNameValue = +filterName!;
+      result = origin?.includes(filterNameValue);
     }
 
     return result;
@@ -198,6 +213,10 @@ export const CheckboxLeftsideFilterForm: React.FC<ICheckboxLeftsideFilterFormPro
         (filter) =>
           (filterType === QueryTypeEnum.REGIONS &&
             !getUsersPresentProperty(filter.name)) ||
+          (filterType === QueryTypeEnum.DIRECTIONS &&
+            !getUsersPresentProperty(filter.name)) ||
+          (filterType === QueryTypeEnum.ORIGINS &&
+            !getUsersPresentProperty(filter.id)) ||
           checkWhetherDisabledDirection(filter.name) ||
           checkWhetherDisabledPostType(Number(filter.id)),
       ),
@@ -251,7 +270,14 @@ export const CheckboxLeftsideFilterForm: React.FC<ICheckboxLeftsideFilterFormPro
     const disabledRegionItem =
       !getUsersPresentProperty(filterName) &&
       filterType === QueryTypeEnum.REGIONS;
-    let disabledDirectionItem = false;
+
+    const disabledOriginItem =
+      !getUsersPresentProperty(filter.id) &&
+      filterType === QueryTypeEnum.ORIGINS;
+
+    let disabledDirectionItem =
+      !getUsersPresentProperty(filterName) &&
+      filterType === QueryTypeEnum.DIRECTIONS;
 
     if (disabledDirections?.length) {
       disabledDirectionItem = checkWhetherDisabledDirection(filterName);
@@ -263,7 +289,10 @@ export const CheckboxLeftsideFilterForm: React.FC<ICheckboxLeftsideFilterFormPro
     }
 
     const disabledFilter =
-      disabledRegionItem || disabledDirectionItem || disabledPostTypeItem;
+      disabledRegionItem ||
+      disabledDirectionItem ||
+      disabledOriginItem ||
+      disabledPostTypeItem;
 
     return (
       <>

--- a/src/old/lib/components/Filters/__test__/CheckboxLeftsideFilterForm.test.tsx
+++ b/src/old/lib/components/Filters/__test__/CheckboxLeftsideFilterForm.test.tsx
@@ -89,7 +89,7 @@ describe('Filters renders correctly', () => {
     const result = screen
       .getAllByRole('checkbox')
       .every((item) => item.hasAttribute('checked'));
-    expect(result).toEqual(true);
+    expect(result).toEqual(false);
   });
   it('User click on checkbox', () => {
     const checkbox = screen.getAllByRole('checkbox')[0];
@@ -103,7 +103,7 @@ describe('Filters renders correctly', () => {
     const result = screen
       .getAllByRole('checkbox')
       .every((item) => item.hasAttribute('checked'));
-    expect(result).toEqual(true);
+    expect(result).toEqual(false);
   });
 });
 


### PR DESCRIPTION
Pull Request Template
 

### Type of Pull Request *
- [ ] CHANGE (fix or feature that would cause existing functionality to not work as expected)
- [ ] FEATURE (non-breaking change which adds functionality)
- [x] BUGFIX (non-breaking change which fixes an issue)
- [ ] ENHANCEMENT  (non-breaking change which improves existing functionality)
- [ ] NONE (if none of the other choices apply. For example, tooling, build system, CI, docs, etc.)

### Related links
 
**Story link**
[#217 Materials page's filters(mobile)](https://github.com/ita-social-projects/dokazovi-requirements/issues/217)
 
### Description *
Describe the big picture of your changes here.
Fixed bug #465 for Filters on 'Матеріали' page (mobile)
 
###Summary of issue
'Переклади' item for which there is no information is not displayed in gray and available for selection.
 
###Summary of change
'Переклади' item for which there is no information is not displayed in gray and available for selection.
 
 
 
"*" - mandatory field
