### PR TITLE
Issue 383 button delete in action buttons

### DIFF
--- a/src/models/adminLab/index.ts
+++ b/src/models/adminLab/index.ts
@@ -8,6 +8,7 @@ export {
   setPage,
   setFiltersToInit,
   setField,
+  removePost,
 } from './reducers';
 export { getMaterialsAction, archiveAdminPost } from './asyncActions';
 export { selectAdminLab, selectMeta } from './selectors';

--- a/src/models/adminLab/reducers.ts
+++ b/src/models/adminLab/reducers.ts
@@ -79,6 +79,11 @@ const adminLabSlice = createSlice({
         [editedPostID]: action.payload,
       };
     },
+    removePost: (state, action: PayloadAction<number>) => {
+      state.data.postIds = state.data.postIds?.filter(
+        (id) => id !== action.payload,
+      );
+    },
   },
   extraReducers: {
     ...getAsyncActionsReducer(getMaterialsAction as any),
@@ -103,5 +108,6 @@ export const {
   setPage,
   setFiltersToInit,
   setField,
+  removePost,
 } = adminLabSlice.actions;
 export const adminLabReducer = adminLabSlice.reducer;

--- a/src/views/Profile/AdminTable/ActionButtons.tsx
+++ b/src/views/Profile/AdminTable/ActionButtons.tsx
@@ -1,18 +1,15 @@
 import React, { useState } from 'react';
 import { Link } from 'react-router-dom';
+import { toast } from 'react-toastify';
 import { Button, MenuItem, Menu, Box } from '@material-ui/core';
 import { MoreVert } from '@material-ui/icons';
 import { useTranslation } from 'react-i18next';
-import { archiveAdminPost } from '../../../models/adminLab';
+import { archiveAdminPost, removePost } from '../../../models/adminLab';
 import { useActions } from '../../../shared/hooks';
 import { useStyles } from './styles/ActionButtons.styles';
 import { langTokens } from '../../../locales/localizationInit';
 import { DeleteConfirmationModal } from './DeleteConfirmationModal';
-import {
-  deletePostById,
-  getPostById,
-} from '../../../old/lib/utilities/API/api';
-import { toast } from 'react-toastify';
+import { deletePostById } from '../../../old/lib/utilities/API/api';
 
 interface IActionButtons {
   id: number;
@@ -22,7 +19,10 @@ interface IActionButtons {
 const ActionButtons: React.FC<IActionButtons> = ({ id, status }) => {
   const classes = useStyles();
   const { t } = useTranslation();
-  const [boundedArchiveAdminPost] = useActions([archiveAdminPost]);
+  const [boundedArchiveAdminPost, boundedRemovePost] = useActions([
+    archiveAdminPost,
+    removePost,
+  ]);
   const editPostLink = `/edit-post?id=${id}`;
 
   const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
@@ -54,8 +54,8 @@ const ActionButtons: React.FC<IActionButtons> = ({ id, status }) => {
       const response = await deletePostById(Number(id));
       if (response.data.success) {
         toast.success(`${t(langTokens.materials.materialDeletedSuccess)}!`);
-        // history.go(-1);
       }
+      boundedRemovePost(Number(id));
     } catch (e) {
       toast.success(`${t(langTokens.materials.materialDeletedFail)}.`);
     }

--- a/src/views/Profile/AdminTable/AdminTableBody.tsx
+++ b/src/views/Profile/AdminTable/AdminTableBody.tsx
@@ -72,7 +72,7 @@ const AdminTableBody: React.FC = () => {
         <TableCell>{modifiedViewsCounter}</TableCell>
         <TableCell>{uniqueViewsCounter}</TableCell>
         <TableCell>
-          <ActionButtons id={id} />
+          <ActionButtons id={id} status={status} />
         </TableCell>
       </TableRow>
     );

--- a/src/views/Profile/AdminTable/DeleteConfirmationModal.tsx
+++ b/src/views/Profile/AdminTable/DeleteConfirmationModal.tsx
@@ -1,0 +1,67 @@
+import React, { useState } from 'react';
+import Button from '@material-ui/core/Button';
+import Dialog from '@material-ui/core/Dialog';
+import DialogTitle from '@material-ui/core/DialogTitle';
+import { Box, Typography } from '@material-ui/core';
+import { useTranslation } from 'react-i18next';
+import { langTokens } from '../../../locales/localizationInit';
+import { useStyles } from '../../../old/lib/components/Modals/confirmationModalWithButton.style';
+
+export interface IDeleteConfirmationModalProps {
+  message: string | JSX.Element;
+  isOpen?: boolean;
+  buttonText?: string;
+  buttonIcon?: JSX.Element;
+  onConfirmButtonClick: () => void;
+  onCancelClick: () => void;
+  loading?: boolean;
+  disabled?: boolean;
+}
+
+export const DeleteConfirmationModal: React.FC<IDeleteConfirmationModalProps> = ({
+  message,
+  onConfirmButtonClick,
+  onCancelClick,
+  isOpen,
+}) => {
+  const { t } = useTranslation();
+  const classes = useStyles();
+
+  return (
+    <Dialog
+      open
+      onClose={onCancelClick}
+      aria-labelledby="alert-dialog-title"
+      aria-describedby="alert-dialog-description"
+    >
+      <DialogTitle className={classes.dialogTitleContainer}>
+        <Typography className={classes.modalText}>{message}</Typography>
+      </DialogTitle>
+      <Box
+        display="flex"
+        justifyContent="center"
+        className={classes.btnContainer}
+      >
+        <Button
+          data-testid="confirmation-button"
+          onClick={() => {
+            onConfirmButtonClick();
+            onCancelClick();
+          }}
+          color="primary"
+          className={[classes.btnConfirm, classes.btn].join(' ')}
+        >
+          {t(langTokens.common.yes)}
+        </Button>
+        <Button
+          onClick={() => onCancelClick()}
+          color="primary"
+          autoFocus
+          className={[classes.btnCancel, classes.btn].join(' ')}
+        >
+          {t(langTokens.common.no)}
+        </Button>
+      </Box>
+    </Dialog>
+  );
+};


### PR DESCRIPTION
Pull Request Template
 

### Type of Pull Request *
- [ ] CHANGE (fix or feature that would cause existing functionality to not work as expected)
- [x] FEATURE (non-breaking change which adds functionality)
- [ ] BUGFIX (non-breaking change which fixes an issue)
- [ ] ENHANCEMENT  (non-breaking change which improves existing functionality)
- [ ] NONE (if none of the other choices apply. For example, tooling, build system, CI, docs, etc.)

### Related links
 
Issue link
[# Issue name]( )
 
  Story link
[#383 Button "Видалити" from Action Button Group]( https://github.com/ita-social-projects/dokazovi-requirements/issues/383)
 
 Description
If Admin clicks on “Видалити” button, a pop-up message “Ви дійсно хочете видалити публікацію?” with choices “Ні” and “Так” appears
If Admin choose “Так” button, next message “Ваша стаття була успішно видалена” should appear
The deleted article disappears from the admin table
If Admin choose “Ні” button, pop-up message disappears
Admin has button “Видалити” in all materials except ones with status "На модерації' in accordance to the requirements [#379 Action Button Group]( https://github.com/ita-social-projects/dokazovi-requirements/issues/379)
 

   Summary of change
Added deletion functionality to action buttons group
 
 
 

