### PR TITLE
#408 Add UpButton on the 'Матеріали' page (change color)

### DIFF
--- a/src/old/lib/components/UpButton/UpButton.styles.ts
+++ b/src/old/lib/components/UpButton/UpButton.styles.ts
@@ -8,14 +8,14 @@ export const useStyles = makeStyles(
         bottom: 20,
         left: 25,
         padding: '12px 10px',
-        backgroundColor: '#000000',
-        opacity: '0.4',
+        backgroundColor: '#FF5C00',
+        opacity: '0.8',
         color: 'white',
         borderRadius: '40px',
         zIndex: 1200,
         '&.MuiButton-root:focus': {
-          backgroundColor: '#000000',
-          opacity: '0.4',
+          backgroundColor: '#FF5C00',
+          opacity: '0.8',
         },
       },
       upIcon: {


### PR DESCRIPTION
### Type of Pull Request 
- [ ] CHANGE (fix or feature that would cause existing functionality to not work as expected)
- [ ] FEATURE (non-breaking change which adds functionality)
- [x] BUGFIX (non-breaking change which fixes an issue)
- [ ] ENHANCEMENT  (non-breaking change which improves existing functionality)
- [ ] NONE (if none of the other choices apply. For example, tooling, build system, CI, docs, etc.)

### Related links
 
**Issue link**
[#408 [Bug Report] [Mobile] The 'Up' button does not exist on the 'Матеріали' page](https://github.com/ita-social-projects/dokazovi-requirements/issues/408 )
 
**Story link**
[#209 Materials Page(mobile)](https://github.com/ita-social-projects/dokazovi-requirements/issues/209 )
 
### Description 
The 'Up' button become invisible on footer on the 'Матеріали' page on mobile version.
 
###Summary of issue
The 'Up' button become invisible on footer on the 'Матеріали' page on mobile version.
 
###Summary of change
Change color of the 'Up' button.