### PR TITLE
bugfix508 - relocate materials table to the admin page

### DIFF
--- a/src/old/lib/components/Users/AdminPage/components/OperationView.tsx
+++ b/src/old/lib/components/Users/AdminPage/components/OperationView.tsx
@@ -5,6 +5,7 @@ import ImportantView from './ImportantView';
 import { useStyles } from '../styles/OperationView.styles';
 import { IAdminMenuOption } from '../../../../types';
 import { langTokens } from '../../../../../../locales/localizationInit';
+import { AdminTable } from '../../../../../../views/Profile/AdminTable/AdminTable';
 
 interface IOperationViewProps {
   selectedOption: IAdminMenuOption | Record<string, never>;
@@ -12,42 +13,49 @@ interface IOperationViewProps {
 
 const OperationView: React.FC<IOperationViewProps> = (props) => {
   const { selectedOption } = props;
-  const { section, label, value } = selectedOption;
+  const { value } = selectedOption;
   const classes = useStyles();
   const { t } = useTranslation();
 
   const renderOperationView = () => {
-    if (value === 'important') {
-      const operationView = (
-        <>
-          <Typography component="h2" className="menuTitle">
-            {t(langTokens.admin.selectedImportantMaterials)}
-          </Typography>
-          <ImportantView />
-        </>
-      );
+    switch (value) {
+      case 'important': {
+        const operationView = (
+          <>
+            <Typography component="h2" className="menuTitle">
+              {t(langTokens.admin.selectedImportantMaterials)}
+            </Typography>
+            <ImportantView />
+          </>
+        );
 
-      return operationView;
+        return operationView;
+      }
+      case 'materials': {
+        const operationView = (
+          <>
+            <AdminTable />
+          </>
+        );
+
+        return operationView;
+      }
+      default: {
+        const operationView = (
+          <div className="adminInitialView">
+            <Typography component="span" className="initialMessage">
+              {t(langTokens.admin.selectOption)}
+            </Typography>
+          </div>
+        );
+
+        return operationView;
+      }
     }
-
-    const operationView = (
-      <div className="adminInitialView">
-        <Typography component="span" className="initialMessage">
-          {t(langTokens.admin.selectOption)}
-        </Typography>
-      </div>
-    );
-
-    return operationView;
   };
 
   return (
     <Container className={classes.operationView}>
-      {value && (
-        <Typography component="h1" className="menuPath">
-          {`${section} > ${label}`}
-        </Typography>
-      )}
       {renderOperationView()}
     </Container>
   );

--- a/src/old/lib/components/Users/AdminPage/components/Sidemenu.tsx
+++ b/src/old/lib/components/Users/AdminPage/components/Sidemenu.tsx
@@ -20,6 +20,11 @@ const adminMenuOptions: IAdminMenuOption[] = [
     label: 'Важливе',
     value: 'important',
   },
+  {
+    section: 'Головна',
+    label: 'Керування матеріалами',
+    value: 'materials',
+  },
 ];
 
 const Sidemenu: React.FC<ISidemenuProps> = (props) => {

--- a/src/old/lib/types.ts
+++ b/src/old/lib/types.ts
@@ -232,7 +232,7 @@ export interface IFooterStyleProps {
   isProfilePage: boolean;
 }
 
-export type AdminMenuType = 'important';
+export type AdminMenuType = 'important' | 'materials';
 
 export interface IAdminMenuOption {
   section: string;

--- a/src/views/Profile/AdminTable/AdminTable.tsx
+++ b/src/views/Profile/AdminTable/AdminTable.tsx
@@ -14,7 +14,7 @@ import AdminTableFilters from './AdminTableFilters';
 import AdminTablePagination from './AdminTablePagination';
 import { useActions } from '../../../shared/hooks';
 
-const AdminTable: React.FC = () => {
+export const AdminTable: React.FC = () => {
   const classes = useStyles();
   const [boundedGetMaterialsAction, boundedSetStateToInit] = useActions([
     getMaterialsAction,
@@ -32,7 +32,7 @@ const AdminTable: React.FC = () => {
 
   useEffect(() => {
     boundedGetMaterialsAction();
-  }, [ meta ]);
+  }, [meta]);
 
   return (
     <>
@@ -50,5 +50,3 @@ const AdminTable: React.FC = () => {
     </>
   );
 };
-
-export default AdminTable;

--- a/src/views/Profile/MaterialsView/MaterialsView.tsx
+++ b/src/views/Profile/MaterialsView/MaterialsView.tsx
@@ -4,7 +4,7 @@ import { IExpert } from '../../../old/lib/types';
 import { selectAuthorities } from '../../../models/authorities';
 import MaterialsDraft from './MaterialsDraft';
 import MaterialsPublished from './MaterialsPublished';
-import AdminTable from '../AdminTable/AdminTable';
+import { AdminTable } from '../AdminTable/AdminTable';
 
 export interface IExpertProfileViewProps {
   expert: IExpert;

--- a/src/views/Profile/Sidemenu.tsx
+++ b/src/views/Profile/Sidemenu.tsx
@@ -20,10 +20,6 @@ const profileMenuOptions: IProfileMenuOption[] = [
     value: 'info',
   },
   {
-    label: i18n.t(langTokens.common.materials),
-    value: 'materials',
-  },
-  {
     label: i18n.t(langTokens.common.passwordChange),
     value: 'passwordChange',
   },


### PR DESCRIPTION
Type of Pull Request 
- [ ] CHANGE (fix or feature that would cause existing functionality to not work as expected)
- [ ] FEATURE (non-breaking change which adds functionality)
- [x] BUGFIX (non-breaking change which fixes an issue)
- [ ] ENHANCEMENT  (non-breaking change which improves existing functionality)
- [ ] NONE (if none of the other choices apply. For example, tooling, build system, CI, docs, etc.)


[#508]( https://github.com/ita-social-projects/dokazovi-requirements/issues/508)
[#512]( https://github.com/ita-social-projects/dokazovi-requirements/issues/512)

 
Description:
Materials table has been relocated from the personal account page to administration page. Tab name adjusted (according to 512 issue)
