### PR TITLE
bug 538 fixed, posts cards are displayed now

### DIFF
--- a/src/models/materials/asyncActions.ts
+++ b/src/models/materials/asyncActions.ts
@@ -5,6 +5,7 @@ import { LOAD_POSTS_LIMIT } from '../../old/lib/constants/posts';
 import { IPost } from '../../old/lib/types';
 import { PostResponseType } from '../../old/lib/utilities/API/types';
 import { IFetchMaterialsOptions } from './types';
+import { StatusesForActions } from '../adminLab/types';
 
 export const mapFetchedPosts = (
   posts: PostResponseType[],
@@ -28,7 +29,7 @@ export const fetchMaterials = createAsyncThunk(
           directions: filters.directions,
           origins: filters.origins,
           sort: ['published_at,desc'],
-          statuses: [3],
+          statuses: [StatusesForActions.PUBLISHED],
         },
       });
 


### PR DESCRIPTION
### Type of Pull Request 
- [ ] CHANGE (fix or feature that would cause existing functionality to not work as expected)
- [ ] FEATURE (non-breaking change which adds functionality)
- [x] BUGFIX (non-breaking change which fixes an issue)
- [ ] ENHANCEMENT  (non-breaking change which improves existing functionality)
- [ ] NONE (if none of the other choices apply. For example, tooling, build system, CI, docs, etc.)

### Related links
 
**Issue link**
[#538](https://github.com/ita-social-projects/dokazovi-requirements/issues/538)
 
### Description 
bug fixed, materials are being displayed 