### PR TITLE
Bugfix558: fixed filter checkbox on materials page

### DIFF
--- a/src/old/modules/materials/components/MaterialsView.tsx
+++ b/src/old/modules/materials/components/MaterialsView.tsx
@@ -227,14 +227,21 @@ const MaterialsView: React.FC = () => {
     const isQuerySame = uniq(Object.values(checked)).length === 1; // removing the query if user checks/unchecks the last box
     query.set(queryType, checkedIds.join(','));
     if (!checkedIds.length || isQuerySame) {
-      query.set(queryType, '0');
+      query.delete(queryType);
     }
 
     setPage(0);
 
-    history.push({
-      search: query.toString(),
-    });
+    if (isQuerySame && uniq(Object.values(checked))[0] === false) {
+      query.set(queryType, '0');
+      history.push({
+        search: query.toString(),
+      });
+    } else {
+      history.push({
+        search: query.toString(),
+      });
+    }
   };
 
   const loadMore = () => {
@@ -265,10 +272,7 @@ const MaterialsView: React.FC = () => {
     query.get(QueryTypeEnum.DIRECTIONS),
   ]);
 
-  const selectedOriginsString =
-    query.get(QueryTypeEnum.ORIGINS) === '0'
-      ? stringOfOrigins().split(' ')
-      : query.get(QueryTypeEnum.ORIGINS)?.split(',');
+  const selectedOriginsString = query.get(QueryTypeEnum.ORIGINS)?.split(',');
 
   let selectedOrigins:
     | IOrigin[]
@@ -286,10 +290,9 @@ const MaterialsView: React.FC = () => {
     }
   }
 
-  const selectedDirectionsString =
-    query.get(QueryTypeEnum.DIRECTIONS) === '0'
-      ? stringOfPostTypes().split(' ')
-      : query.get(QueryTypeEnum.DIRECTIONS)?.split(',');
+  const selectedDirectionsString = query
+    .get(QueryTypeEnum.DIRECTIONS)
+    ?.split(',');
 
   let selectedDirections:
     | IDirection[]
@@ -308,10 +311,9 @@ const MaterialsView: React.FC = () => {
     }
   }
 
-  const selectedPostTypesString =
-    query.get(QueryTypeEnum.POST_TYPES) === '0'
-      ? stringOfPostTypes().split(' ')
-      : query.get(QueryTypeEnum.POST_TYPES)?.split(',');
+  const selectedPostTypesString = query
+    .get(QueryTypeEnum.POST_TYPES)
+    ?.split(',');
 
   let selectedPostTypes:
     | IPostType[]


### PR DESCRIPTION
Pull Request Template
 

### Type of Pull Request *
- [ ] CHANGE (fix or feature that would cause existing functionality to not work as expected)
- [ ] FEATURE (non-breaking change which adds functionality)
- [x] BUGFIX (non-breaking change which fixes an issue)
- [ ] ENHANCEMENT  (non-breaking change which improves existing functionality)
- [ ] NONE (if none of the other choices apply. For example, tooling, build system, CI, docs, etc.)

### Related links
 
**Issue link**
[#558 Bug Report]( https://github.com/ita-social-projects/dokazovi-requirements/issues/558)
 
**Story link**
[#236 Story](https://github.com/ita-social-projects/dokazovi-be/issues/236 )
 
### Description *
Filter are removed in the 'за джерелом', 'за типом', 'за темою' sections after clicking on the last checked checkbox. 

 
###Summary of change
Updated query to change it properly after clicking on checkboxes. 
 
 
