### PR TITLE
Bug fix 147 clicking on the video card image

### DIFF
--- a/src/components/Posts/Cards/VideoPostPreviewCard/VideoPostPreviewCard.tsx
+++ b/src/components/Posts/Cards/VideoPostPreviewCard/VideoPostPreviewCard.tsx
@@ -29,6 +29,7 @@ export const VideoPostPreviewCard: React.FC<IPostPreviewCardProps> = ({
           <Box className={classes.play} data-testid="videoIcon" />
         )}
         <iframe
+          style={{ pointerEvents: post.videoUrl ? 'inherit' : 'none' }}
           src={url}
           width="100%"
           height="100%"


### PR DESCRIPTION
Pull Request Template
 

### Type of Pull Request *
- [] CHANGE (fix or feature that would cause existing functionality to not work as expected)
- [ ] FEATURE (non-breaking change which adds functionality)
- [x] BUGFIX (non-breaking change which fixes an issue)
- [ ] ENHANCEMENT  (non-breaking change which improves existing functionality)
- [ ] NONE (if none of the other choices apply. For example, tooling, build system, CI, docs, etc.)

### Related links
 
**Issue link**
[[Bug Report] 'Main' page - User is not redirected after clicking on the Card image of the Material card Style 1 (type 'Video') #147](https://github.com/ita-social-projects/dokazovi-requirements/issues/147 )
 
**Story link**
[[Change request] To redesign material card view #229](https://github.com/ita-social-projects/dokazovi-be/issues/229)
 
### Description *
Wrong behavior in material card with type 'Video'. 
 
###Summary of issue
You are still on the same page. You are not redirected.
 
###Summary of change
Added pointer event "none" if iframe url is empty.
 
 