### PR TITLE
Bug fix 591 "Керування матеріалами": content is not fully displayed

### DIFF
--- a/src/old/lib/components/Users/AdminPage/styles/AdminPageWrapper.styles.ts
+++ b/src/old/lib/components/Users/AdminPage/styles/AdminPageWrapper.styles.ts
@@ -5,6 +5,9 @@ export const useStyles = makeStyles(
     container: {
       overflowX: 'auto',
       paddingTop: '10px',
+      display: 'grid',
+      gridTemplateColumns: '200px 1fr',
+      margin: '0 -50px',
     },
   }),
   { name: 'AdminPageWrapper' },

--- a/src/old/lib/components/Users/AdminPage/styles/OperationView.styles.ts
+++ b/src/old/lib/components/Users/AdminPage/styles/OperationView.styles.ts
@@ -6,7 +6,6 @@ export const useStyles = makeStyles(
       fontFamily: 'Raleway',
       position: 'relative',
       minHeight: '455px',
-      paddingLeft: '110px',
       '& .adminInitialView': {
         position: 'absolute',
         top: '30%',

--- a/src/old/lib/components/Users/AdminPage/styles/Sidemenu.styles.ts
+++ b/src/old/lib/components/Users/AdminPage/styles/Sidemenu.styles.ts
@@ -15,7 +15,7 @@ export const useStyles = makeStyles(
       height: '100%',
       paddingTop: theme.spacing(2),
       backgroundColor: '#e5e5e5',
-      position: 'absolute',
+      position: 'static',
       border: 'none',
     },
     menuCategory: {


### PR DESCRIPTION
Pull Request Template
 

### Type of Pull Request *
- [ ] CHANGE (fix or feature that would cause existing functionality to not work as expected)
- [ ] FEATURE (non-breaking change which adds functionality)
- [x] BUGFIX (non-breaking change which fixes an issue)
- [ ] ENHANCEMENT  (non-breaking change which improves existing functionality)
- [ ] NONE (if none of the other choices apply. For example, tooling, build system, CI, docs, etc.)

### Related links
 
[#591 Bug Report](https://github.com/ita-social-projects/dokazovi-requirements/issues/591 )
 
[#469 Story](https://github.com/ita-social-projects/dokazovi-requirements/issues/469)
 
### Description 
 Content is not fully displayed on the "Керування матеріалами" page.

###Summary of change
Changed layout to the `display: grid`.  

