### PR TITLE
Issue 598 (author) send material for moderation

### DIFF
--- a/src/locales/uk/parts/admin.ts
+++ b/src/locales/uk/parts/admin.ts
@@ -55,6 +55,8 @@ export const admin = {
   imagesTablet: 'Зображення для планшета',
   review: 'Переглянути',
   sendForReview: 'Відправити на модерацію',
+  sendForReviewTitle: 'Відправити публікацію на модерацію?',
+  sendForReviewSuccess: 'Ваша стаття була успішно відправлена на модерацію',
   close: 'Закрити',
   selectedImportantMaterials: 'Зараз використовуються:',
   selectOption: `Оберіть об'єкт налаштування у меню`,

--- a/src/locales/uk/parts/editor.ts
+++ b/src/locales/uk/parts/editor.ts
@@ -12,6 +12,7 @@ export const editor = {
   preview: 'Попередній перегляд',
   publish: 'Опублікувати',
   save: 'Зберегти',
+  sendToReview: 'Відправити на модерацію',
   creation: 'Створення',
   updation: 'Редагування',
   videoTitle: 'Заголовок відео',

--- a/src/views/Profile/AdminTable/ActionButtons.tsx
+++ b/src/views/Profile/AdminTable/ActionButtons.tsx
@@ -95,6 +95,15 @@ const ActionButtons: React.FC<IActionButtons> = ({
     closeModal();
   };
 
+  const handleSendToReviewConfirm = () => {
+    boundedSetPostStatus({
+      id,
+      postStatus: StatusesForActions.MODERATION_SECOND_SIGN,
+    });
+    toast.success(t(langTokens.admin.sendForReviewSuccess));
+    closeModal();
+  };
+
   const handleReturnConfirm = () => {
     boundedSetPostStatus({
       id,
@@ -159,6 +168,17 @@ const ActionButtons: React.FC<IActionButtons> = ({
         onConfirmButtonClick: handlePublishConfirm,
       },
       adminUseStatuses: [MODERATION_SECOND_SIGN, ARCHIVED, PLANNED],
+      authorUseStatuses: [DRAFT, NEEDS_EDITING],
+    },
+    {
+      id: 'sentToModerationBtn',
+      label: t(langTokens.admin.sendForReview),
+      handler: (btnId) => openModal(btnId),
+      modal: {
+        title: t(langTokens.admin.sendForReviewTitle),
+        onConfirmButtonClick: handleSendToReviewConfirm,
+      },
+      adminUseStatuses: [],
       authorUseStatuses: [DRAFT, NEEDS_EDITING],
     },
     {

--- a/src/views/Profile/AdminTable/ActionButtons.tsx
+++ b/src/views/Profile/AdminTable/ActionButtons.tsx
@@ -168,7 +168,7 @@ const ActionButtons: React.FC<IActionButtons> = ({
         onConfirmButtonClick: handlePublishConfirm,
       },
       adminUseStatuses: [MODERATION_SECOND_SIGN, ARCHIVED, PLANNED],
-      authorUseStatuses: [DRAFT, NEEDS_EDITING],
+      authorUseStatuses: [],
     },
     {
       id: 'sentToModerationBtn',

--- a/src/views/postCreation/PostCreationButtons.spec.tsx
+++ b/src/views/postCreation/PostCreationButtons.spec.tsx
@@ -40,6 +40,7 @@ describe('PostCreationButton test', () => {
         onPublishClick={publish}
         onPreviewClick={jest.fn}
         onSaveClick={jest.fn}
+        isAdmin
       />,
     );
     expect(asFragment()).toMatchSnapshot();
@@ -52,6 +53,7 @@ describe('PostCreationButton test', () => {
         onPreviewClick={jest.fn}
         onSaveClick={jest.fn}
         isModal={{ isTooLong: true, isEmpty: false, isEnoughLength: false }}
+        isAdmin
       />,
     );
     const publishButton = screen.getByText('Опублікувати');
@@ -66,6 +68,7 @@ describe('PostCreationButton test', () => {
         onPreviewClick={jest.fn}
         onSaveClick={jest.fn}
         isModal={{ isEmpty: true, isEnoughLength: false }}
+        isAdmin
       />,
     );
     const publishButton = screen.getByText('Зберегти');
@@ -84,6 +87,7 @@ describe('PostCreationButton test', () => {
         onPreviewClick={jest.fn}
         onSaveClick={jest.fn}
         isModal={{ isEmpty: false, isEnoughLength: true }}
+        isAdmin
       />,
     );
     const publishButton = screen.getByText('Опублікувати');
@@ -112,7 +116,6 @@ describe('PostCreationButton test', () => {
     render(
       <PostCreationButtons
         action="updating"
-        isAdmin
         onPublishClick={publish}
         onPreviewClick={jest.fn}
         onSaveClick={jest.fn}
@@ -123,6 +126,7 @@ describe('PostCreationButton test', () => {
           hasBackGroundImg: true,
         }}
         post={mockPost}
+        isAdmin
       />,
     );
     const publishButton = screen.getByText('Опублікувати');
@@ -141,6 +145,7 @@ describe('PostCreationButton test', () => {
         onPreviewClick={jest.fn}
         onSaveClick={jest.fn}
         previewing
+        isAdmin
       />,
     );
     const cancelButton = screen.getByText('Відмінити створення');
@@ -166,5 +171,17 @@ describe('PostCreationButton test', () => {
     expect(
       screen.getByText(`Ви дійсно бажаєте відмінити Редагування?`),
     ).toBeInTheDocument();
+  });
+  it('should render sendToReview Button for Author user', () => {
+    render(
+      <PostCreationButtons
+        action="creating"
+        onPublishClick={publish}
+        onPreviewClick={jest.fn}
+        onSaveClick={jest.fn}
+        isAdmin={false}
+      />,
+    );
+    expect(screen.getByText('Відправити на модерацію')).toBeInTheDocument();
   });
 });

--- a/src/views/postCreation/PostCreationButtons.tsx
+++ b/src/views/postCreation/PostCreationButtons.tsx
@@ -53,7 +53,9 @@ export const PostCreationButtons: React.FC<IPostCreationButtonsProps> = ({
     ? t(langTokens.editor.backToUpdation)
     : t(langTokens.editor.preview);
   const saveButtonText = t(langTokens.editor.save);
-  const publishButtonText = t(langTokens.editor.publish);
+  const publishButtonText = isAdmin
+    ? t(langTokens.editor.publish)
+    : t(langTokens.editor.sendToReview);
 
   const modalMaker = (message: string) => {
     setModalMessage(message);


### PR DESCRIPTION

### Type of Pull Request *
- [ ] CHANGE (fix or feature that would cause existing functionality to not work as expected)
- [x] FEATURE (non-breaking change which adds functionality)
- [x] BUGFIX (non-breaking change which fixes an issue)
- [ ] ENHANCEMENT  (non-breaking change which improves existing functionality)
- [ ] NONE (if none of the other choices apply. For example, tooling, build system, CI, docs, etc.)

### Related links
 
**Issue link**
[#594 [Bug Report] ‘Матеріали’ page: The dropdown lists of the ʼПотребує редагуванняʼ, ‘Чернетка’ statuses are not correspond to mockup in the Action Button Group ](https://github.com/ita-social-projects/dokazovi-requirements/issues/594 )
[#598 (Author) Send Material for Moderation](https://github.com/ita-social-projects/dokazovi-requirements/issues/598 )
 

 
### Description *
Change "Опублікувати" button in Editor to "Відправити на модерацію" for Author;
Add "Відправити на модерацію" button to action button group in Author materials table for "Потребує редагування" and "Чернутка" publications statuses;
On "Відправити на модерацію" button click publication status changes to "На модерації" for author and admin;
Delete publish button from action button group in Author materials table

 
