### PR TITLE
Bug#593 access token expiration not handled

### DIFF
--- a/src/old/lib/utilities/API/api.ts
+++ b/src/old/lib/utilities/API/api.ts
@@ -50,12 +50,20 @@ instance.interceptors.request.use(
 );
 
 instance.interceptors.response.use(undefined, (error: AxiosError) => {
+  const jwtToken = getToken();
+
   if (error.message === 'Network Error' && !error.response) {
     toast.error("The server isn't responding...");
   }
 
   if (!error.response) {
     throw error;
+  }
+
+  if (error.response.status === 401 && jwtToken) {
+    localStorage.removeItem('ACCESS_TOKEN');
+    localStorage.removeItem('PERMISSIONS');
+    document.location.href = '/opendoctorgate';
   }
 
   if (error.response.status === 500) {


### PR DESCRIPTION


Type of Pull Request 
- [ ] CHANGE (fix or feature that would cause existing functionality to not work as expected)
- [ ] FEATURE (non-breaking change which adds functionality)
- [x] BUGFIX (non-breaking change which fixes an issue)
- [ ] ENHANCEMENT  (non-breaking change which improves existing functionality)
- [ ] NONE (if none of the other choices apply. For example, tooling, build system, CI, docs, etc.)

### Related links
 
**Issue link**
[#593 [Bug Report] Main page: Access token is not refreshed on the website](https://github.com/ita-social-projects/dokazovi-requirements/issues/593)
 
**Story link**
[#166 Administrator's page security](https://github.com/ita-social-projects/dokazovi-requirements/issues/166)
 
### Description *
The administrator not logged out of the website after access token is expired
 
###Summary of change
-add user logout after access token is expired;
-add redirect to login page;
 
 
 
