### PR TITLE
bug: update modify-post method

### DIFF
--- a/src/old/lib/utilities/API/api.ts
+++ b/src/old/lib/utilities/API/api.ts
@@ -240,7 +240,7 @@ export const createPost = async (
 export const updatePost = async (
   requestBody: UpdatePostRequestUnionType,
 ): Promise<AxiosResponse<PostResponseType>> => {
-  return instance.post(`/post`, requestBody);
+  return instance.put(`/post`, requestBody);
 };
 
 export const login = async (

--- a/src/views/postUpdation/AllPostTypesUpdation.tsx
+++ b/src/views/postUpdation/AllPostTypesUpdation.tsx
@@ -287,7 +287,8 @@ export const AllPostTypesUpdation: React.FC<IAllPostTypesUpdation> = ({
       ? StatusesForActions.PUBLISHED
       : StatusesForActions.MODERATION_SECOND_SIGN;
     const response = await updatePost(updatedPost);
-    history.push(`/posts/${response.data.id}`);
+    console.log(response.data);
+    history.push(`/posts/${updatedPost.id}`);
   };
 
   const handleSaveClick = async () => {
@@ -297,7 +298,8 @@ export const AllPostTypesUpdation: React.FC<IAllPostTypesUpdation> = ({
       updatedPost.postStatus = 0;
     }
     const response = await updatePost(updatedPost);
-    history.push(`/posts/${response.data.id}`);
+    console.log(response.data);
+    history.push(`/posts/${updatedPost.id}`);
   };
 
   const postOriginSelector = isAdmin && (

--- a/src/views/postUpdation/AllPostTypesUpdation.tsx
+++ b/src/views/postUpdation/AllPostTypesUpdation.tsx
@@ -286,8 +286,7 @@ export const AllPostTypesUpdation: React.FC<IAllPostTypesUpdation> = ({
     updatedPost.postStatus = isAdmin
       ? StatusesForActions.PUBLISHED
       : StatusesForActions.MODERATION_SECOND_SIGN;
-    const response = await updatePost(updatedPost);
-    console.log(response.data);
+    await updatePost(updatedPost);
     history.push(`/posts/${updatedPost.id}`);
   };
 
@@ -297,8 +296,7 @@ export const AllPostTypesUpdation: React.FC<IAllPostTypesUpdation> = ({
     } else {
       updatedPost.postStatus = 0;
     }
-    const response = await updatePost(updatedPost);
-    console.log(response.data);
+    await updatePost(updatedPost);
     history.push(`/posts/${updatedPost.id}`);
   };
 


### PR DESCRIPTION
Pull Request Template
 

### Type of Pull Request *
- [ ] CHANGE (fix or feature that would cause existing functionality to not work as expected)
- [ ] FEATURE (non-breaking change which adds functionality)
- [ ] BUGFIX (non-breaking change which fixes an issue)
- [x] ENHANCEMENT  (non-breaking change which improves existing functionality)
- [ ] NONE (if none of the other choices apply. For example, tooling, build system, CI, docs, etc.)

### Related links
 
**Issue link**

 
**Story link**

 
### Description *
There is `createdAt` and `modifyAt` collision issue for posts. Which happens because each time when we update a post - "create a new post" event has been triggered.
 
### Summary of issue

 
### Summary of change
Use `put` method for sending updates on existing posts.
 
 
 
"*" - mandatory field
