### PR TITLE
bugfix #597 make navigation to edit page instead of opening in new tab

### DIFF
--- a/src/views/Profile/AdminTable/ActionButtons.tsx
+++ b/src/views/Profile/AdminTable/ActionButtons.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { useHistory } from 'react-router-dom';
 import { MenuItem } from '@material-ui/core';
 import { useTranslation } from 'react-i18next';
 import { toast } from 'react-toastify';
@@ -57,6 +58,7 @@ const ActionButtons: React.FC<IActionButtons> = ({
   } = PostStatus;
 
   const editPostLink = `/edit-post?id=${id}`;
+  const history = useHistory();
   const [activeModal, setActiveModal] = useState<null | string>(null);
 
   const openModal = (modal: string) => {
@@ -135,7 +137,7 @@ const ActionButtons: React.FC<IActionButtons> = ({
       label: t(langTokens.admin.edit),
       modal: null,
       handler: () => {
-        window.open(editPostLink);
+        history.push(editPostLink);
       },
       adminUseStatuses: [
         PUBLISHED,


### PR DESCRIPTION
 
### Type of Pull Request *
- [ ] CHANGE (fix or feature that would cause existing functionality to not work as expected)
- [ ] FEATURE (non-breaking change which adds functionality)
- [x] BUGFIX (non-breaking change which fixes an issue)
- [ ] ENHANCEMENT  (non-breaking change which improves existing functionality)
- [ ] NONE (if none of the other choices apply. For example, tooling, build system, CI, docs, etc.)

### Related links
 
**Issue link**

[bugFix #597](https://github.com/ita-social-projects/dokazovi-requirements/issues/597 )

 
### Description *
Previously when user clicked "Редагувати" button on publication - it opened in new tab, so when user confirmed "Відмінити редагування" nothing happened, because logic was to go back in history when user clicks "Так". Now, instead of opening in new window, user just navigates to the edit page, so when user cancels editing, he returns to previous page.
 
