### PR TITLE
Add button to cancel changes, add eventListener to handle closing tab…

### DIFF
--- a/src/components/Form/Buttons/BasicButton.tsx
+++ b/src/components/Form/Buttons/BasicButton.tsx
@@ -37,7 +37,6 @@ export const BasicButton: React.FC<IBasicButtonProps> = ({
       className={clsx(getRootClass(), className)}
       type="submit"
       variant="contained"
-      fullWidth
       disabled={disabled}
       onClick={onClick}
     >

--- a/src/components/Form/Buttons/CancelButton.tsx
+++ b/src/components/Form/Buttons/CancelButton.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { Button } from '@material-ui/core';
+import { useStyles } from './styles/CancelButton.style';
+
+type CancelButtonPropsType = {
+  label: string;
+  onClick?: React.MouseEventHandler<HTMLButtonElement>;
+};
+export const CancelButton: React.FC<CancelButtonPropsType> = ({
+  label,
+  onClick,
+}) => {
+  const classes = useStyles();
+
+  return (
+    <Button
+      className={classes.cancelButton}
+      variant="contained"
+      onClick={onClick}
+    >
+      {label}
+    </Button>
+  );
+};

--- a/src/components/Form/Buttons/__tests__/CancelButton.test.tsx
+++ b/src/components/Form/Buttons/__tests__/CancelButton.test.tsx
@@ -1,0 +1,27 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import userEvent, { TargetElement } from '@testing-library/user-event';
+import { CancelButton } from '../CancelButton';
+
+describe('Test for CancelButton component', () => {
+  it('Should render a button', () => {
+    const { container } = render(<CancelButton label="Hello world" />);
+    expect(container.firstChild).toHaveClass('CancelButton-cancelButton-1');
+  });
+
+  it('Should render a label properly', () => {
+    render(<CancelButton label="Hello world" />);
+    const label = screen.getByText('Hello world');
+
+    expect(label).toBeInTheDocument();
+  });
+
+  it('Should handle onClick', () => {
+    const handleClick = jest.fn();
+    const { container } = render(
+      <CancelButton label="Hello World" onClick={handleClick} />,
+    );
+    userEvent.click(container.firstChild as TargetElement);
+    expect(handleClick).toBeCalled();
+  });
+});

--- a/src/components/Form/Buttons/index.ts
+++ b/src/components/Form/Buttons/index.ts
@@ -1,1 +1,2 @@
 export { BasicButton } from './BasicButton';
+export { CancelButton } from './CancelButton';

--- a/src/components/Form/Buttons/styles/BasicButton.style.tsx
+++ b/src/components/Form/Buttons/styles/BasicButton.style.tsx
@@ -28,7 +28,6 @@ export const useStyles = makeStyles(
         flex: '0 1 auto',
         padding: theme.spacing(2, 3.1),
         '& .MuiButton-label': {
-          fontWeight: 600,
           fontSize: '15px',
         },
       },

--- a/src/components/Form/Buttons/styles/BasicButton.style.tsx
+++ b/src/components/Form/Buttons/styles/BasicButton.style.tsx
@@ -5,7 +5,6 @@ export const useStyles = makeStyles(
     basicAcceptButton: {
       marginTop: theme.spacing(7),
       padding: theme.spacing(3.7, 2.8),
-      fontFamily: 'Raleway',
       fontWeight: 600,
       fontSize: theme.spacing(3.6),
     },
@@ -19,7 +18,6 @@ export const useStyles = makeStyles(
         color: theme.palette.common.white,
         fontWeight: 700,
         fontSize: '18px',
-        fontFamily: 'Raleway',
       },
       '&:hover': {
         backgroundColor: '#ffaa00',

--- a/src/components/Form/Buttons/styles/CancelButton.style.tsx
+++ b/src/components/Form/Buttons/styles/CancelButton.style.tsx
@@ -9,7 +9,6 @@ export const useStyles = makeStyles(
         color: theme.palette.common.white,
         fontWeight: 700,
         fontSize: '18px',
-        fontFamily: 'Raleway',
       },
       '&:hover': {
         backgroundColor: theme.palette.info.main,

--- a/src/components/Form/Buttons/styles/CancelButton.style.tsx
+++ b/src/components/Form/Buttons/styles/CancelButton.style.tsx
@@ -17,7 +17,6 @@ export const useStyles = makeStyles(
       [theme.breakpoints.down('sm')]: {
         flex: '0 1 auto',
         '& .MuiButton-label': {
-          fontWeight: 600,
           fontSize: '15px',
         },
       },

--- a/src/components/Form/Buttons/styles/CancelButton.style.tsx
+++ b/src/components/Form/Buttons/styles/CancelButton.style.tsx
@@ -2,19 +2,9 @@ import { makeStyles, Theme } from '@material-ui/core';
 
 export const useStyles = makeStyles(
   (theme: Theme) => ({
-    basicAcceptButton: {
-      marginTop: theme.spacing(7),
-      padding: theme.spacing(3.7, 2.8),
-      fontFamily: 'Raleway',
-      fontWeight: 600,
-      fontSize: theme.spacing(3.6),
-    },
-    basicSignButton: {
-      padding: theme.spacing(3.2, 8.8),
-      borderRadius: theme.spacing(10),
+    cancelButton: {
       flex: '0 1 300px',
-      marginRight: 0,
-      backgroundColor: '#FF5C00',
+      backgroundColor: theme.palette.info.light,
       '& .MuiButton-label': {
         color: theme.palette.common.white,
         fontWeight: 700,
@@ -22,11 +12,10 @@ export const useStyles = makeStyles(
         fontFamily: 'Raleway',
       },
       '&:hover': {
-        backgroundColor: '#ffaa00',
+        backgroundColor: theme.palette.info.main,
       },
       [theme.breakpoints.down('sm')]: {
         flex: '0 1 auto',
-        padding: theme.spacing(2, 3.1),
         '& .MuiButton-label': {
           fontWeight: 600,
           fontSize: '15px',
@@ -34,7 +23,5 @@ export const useStyles = makeStyles(
       },
     },
   }),
-  {
-    name: 'BasicInput',
-  },
+  { name: 'CancelButton' },
 );

--- a/src/locales/uk/parts/common.ts
+++ b/src/locales/uk/parts/common.ts
@@ -58,6 +58,7 @@ export const common = {
   enterTagName: 'Введіть назву тега',
   showMore: 'Показати ще',
   acceptChanges: 'Підтвердити зміни',
+  cancelChanges: 'Скасувати зміни',
   selectedMaterials: 'Обрані матеріали',
   publishedMaterials: 'Опубліковані матеріали',
   unPublishedMaterials: 'Неопубліковані матеріали',

--- a/src/styles/theme/index.ts
+++ b/src/styles/theme/index.ts
@@ -25,6 +25,9 @@ export const MAIN_THEME = createTheme({
         borderRadius: 0,
         textTransform: 'none',
       },
+      label: {
+        fontFamily: 'Raleway',
+      },
     },
     MuiIconButton: {
       root: {

--- a/src/views/Profile/PersonalInfo/PersonalInfo.tsx
+++ b/src/views/Profile/PersonalInfo/PersonalInfo.tsx
@@ -1,14 +1,14 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import {
   Avatar,
-  Grid,
-  TextField,
-  InputLabel,
   Box,
+  Grid,
   IconButton,
+  InputLabel,
+  TextField,
   Typography,
 } from '@material-ui/core';
-import { BasicButton } from 'components/Form';
+import { BasicButton, CancelButton } from 'components/Form';
 import { PhotoCamera } from '@material-ui/icons';
 import { uploadImageToImgur } from 'old/lib/utilities/Imgur/uploadImageToImgur';
 import { getStringFromFile } from 'old/lib/utilities/Imgur/getStringFromFile';
@@ -44,7 +44,7 @@ export const PersonalInfo: React.FC<IEditAuthorProps> = ({ author }) => {
     twitter: false,
     linkedin: false,
   });
-  const [toggleButton, setToggleButton] = useState(true);
+  const [toggleButton, setToggleButton] = useState(false);
 
   const [newAuthorValues, setNewAuthorValues] = useState<INewAuthorValues>({
     avatar: author?.avatar ?? '',
@@ -199,6 +199,19 @@ export const PersonalInfo: React.FC<IEditAuthorProps> = ({ author }) => {
       }),
     [errorMessages],
   );
+
+  useEffect(() => {
+    const handleBeforeUnload = (e: BeforeUnloadEvent) => {
+      e.preventDefault();
+      e.returnValue =
+        'Зміни не збережені. Ви впевнені, що хочете залишити сторінку?';
+    };
+
+    window.addEventListener('beforeunload', handleBeforeUnload);
+    return () => {
+      window.removeEventListener('beforeunload', handleBeforeUnload);
+    };
+  }, []);
 
   return (
     <form>
@@ -363,7 +376,14 @@ export const PersonalInfo: React.FC<IEditAuthorProps> = ({ author }) => {
           />
         </Grid>
       </Grid>
+
       <Box className={classes.ButtonBox}>
+        {author && (
+          <CancelButton
+            label={i18n.t(langTokens.common.cancelChanges)}
+            onClick={() => window.close()}
+          />
+        )}
         <BasicButton
           disabled={isSaveDisabled}
           type="sign"

--- a/src/views/Profile/PersonalInfo/PersonalInfo.tsx
+++ b/src/views/Profile/PersonalInfo/PersonalInfo.tsx
@@ -215,7 +215,7 @@ export const PersonalInfo: React.FC<IEditAuthorProps> = ({ author }) => {
     return () => {
       window.removeEventListener('beforeunload', handleBeforeUnload);
     };
-  }, [newAuthorValues]);
+  }, [newAuthorValues, previousAuthorValues]);
 
   return (
     <form>

--- a/src/views/Profile/PersonalInfo/PersonalInfo.tsx
+++ b/src/views/Profile/PersonalInfo/PersonalInfo.tsx
@@ -12,6 +12,7 @@ import { BasicButton, CancelButton } from 'components/Form';
 import { PhotoCamera } from '@material-ui/icons';
 import { uploadImageToImgur } from 'old/lib/utilities/Imgur/uploadImageToImgur';
 import { getStringFromFile } from 'old/lib/utilities/Imgur/getStringFromFile';
+import _isEqual from 'lodash/isEqual';
 import { useStyles } from './styles/PersonalInfo.styles';
 import { ErrorField } from './ErrorField';
 import { regex } from './constants/regex';
@@ -26,6 +27,7 @@ import i18n, { langTokens } from '../../../locales/localizationInit';
 import RegionCityHandler from './RegionCityHandler';
 import { validation } from './constants/validation';
 import { validateInput } from './utilities/validateInput';
+import { usePrevious } from '../../../old/lib/hooks/usePrevious';
 
 export const PersonalInfo: React.FC<IEditAuthorProps> = ({ author }) => {
   const classes = useStyles();
@@ -57,6 +59,7 @@ export const PersonalInfo: React.FC<IEditAuthorProps> = ({ author }) => {
     socialNetwork: author?.socialNetworks ?? [null, null, null, null, null],
     work: author?.mainInstitution.name ?? '',
   });
+  const previousAuthorValues = usePrevious<INewAuthorValues>(newAuthorValues);
 
   const errorMessages = useMemo(() => {
     const errors: IErrorFields = {
@@ -202,16 +205,17 @@ export const PersonalInfo: React.FC<IEditAuthorProps> = ({ author }) => {
 
   useEffect(() => {
     const handleBeforeUnload = (e: BeforeUnloadEvent) => {
-      e.preventDefault();
-      e.returnValue =
-        'Зміни не збережені. Ви впевнені, що хочете залишити сторінку?';
+      if (!_isEqual(previousAuthorValues, newAuthorValues)) {
+        e.preventDefault();
+        e.returnValue =
+          'Зміни не збережені. Ви впевнені, що хочете залишити сторінку?';
+      }
     };
-
     window.addEventListener('beforeunload', handleBeforeUnload);
     return () => {
       window.removeEventListener('beforeunload', handleBeforeUnload);
     };
-  }, []);
+  }, [newAuthorValues]);
 
   return (
     <form>

--- a/src/views/Profile/PersonalInfo/styles/PersonalInfo.styles.ts
+++ b/src/views/Profile/PersonalInfo/styles/PersonalInfo.styles.ts
@@ -60,16 +60,20 @@ export const useStyles = makeStyles(
     },
     BasicButton: {
       '& ': {
-        marginTop: theme.spacing(5),
-        width: 300,
         borderRadius: theme.spacing(0),
       },
     },
     ButtonBox: {
       '& ': {
-        width: 'fullwidth',
         display: 'flex',
+        gap: '15px',
+        marginTop: theme.spacing(5),
         justifyContent: 'right',
+      },
+      [theme.breakpoints.down('xs')]: {
+        '& ': {
+          justifyContent: 'center',
+        },
       },
     },
     WrapperBox: {


### PR DESCRIPTION
 
### Type of Pull Request *
- [ ] CHANGE (fix or feature that would cause existing functionality to not work as expected)
- [x] FEATURE (non-breaking change which adds functionality)
- [ ] BUGFIX (non-breaking change which fixes an issue)
- [ ] ENHANCEMENT  (non-breaking change which improves existing functionality)
- [ ] NONE (if none of the other choices apply. For example, tooling, build system, CI, docs, etc.)

### Related links
 
**Issue link**
[#633 Change editing author](https://github.com/ita-social-projects/dokazovi-requirements/issues/633)
 
### Description *
Added button to cancel changes, made a popup which asks user to stay or quit page.

### Summary of change
Cancel button just close the tab, so any changes will not be saved. As we cant make custom popup due to security politics of the browser, I have made a event listener that shows browser popup to ask user leave or not the page. Popup will be shown only if user interacts with a page. Also, made our "Підтвердити зміни" button adaptive, so both buttons have the same behaviour when viewport is changing.
 
